### PR TITLE
Fix: sidebar scroll moving to page

### DIFF
--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -514,8 +514,11 @@ header button {
 }
 
 #comments {
+	flex:1 1 auto;
+	min-height:0;
     overflow:auto;
     overflow-x:hidden;
+	overscroll-behavior:contain;
     padding:8px 12px;
     word-wrap:break-word;
 }
@@ -615,6 +618,12 @@ Loading...
 `;
 
 		const panel = shadow.querySelector("#panel");
+
+		// Stop scroll/touch events moving out of sidebar so sites with
+		// JS scroll hijacking (wheel listeners on window) don't scroll behind
+		for (const type of ["wheel", "touchmove"]) {
+		  host.addEventListener(type, (event) => event.stopPropagation());
+		}
 
 		let resizing = false;
 		let startX = 0;


### PR DESCRIPTION
In Firefox, scrolling inside the comments sidebar scrolls the page behind it. Causes I identified were that
- #comments had no flex sizing so it wasn't constrained to the panel height and wheel events fell through to the page. Even when it did scroll, hitting the top or bottom chained the scroll to the page.
- sites with JS scroll hijacking listen for wheel events on window. I believe those events are moving out of the shadow DOM so the site scrolls the page no matter what the CSS does. Example: unawatch.com (currently on the HN front page, where I found the issue).

Fixed by
- Add flex sizing and overscroll-behavior:contain to #comments so it constrains the scroll container, which stops native scroll chaining
- Stop wheel and touch propagation at the sidebar host so sites with JS scroll hijacking don't scroll the page behind the sidebar

Note that i think capture-phase wheel listeners on window fire before the event reaches the sidebar, I can't come up with a fix for that right now.

Tested on firefox, chrome, safari. You should see the sidebar scroll independently, even though the site has scroll hijacking for the central word banner. Saw no regressions or diffs on chrome and safari. Feel free to edit however you like. Thanks for the tool!