### PR TITLE
Numerous small improvements (v1.4.7)

### DIFF
--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -70,6 +70,19 @@
 	await save(STORAGE.collapsed, ids);
   }
 
+  async function getSeenTime(storyID) {
+	const seen = await load(STORAGE.seen, {});
+	return seen[storyID] || 0;
+  }
+
+  async function markSeen(storyID) {
+	const seen = await load(STORAGE.seen, {});
+
+	seen[storyID] = Math.floor(Date.now() / 1000);
+
+	await save(STORAGE.seen, seen);
+  }
+
   async function toggleCollapsed(id, collapsed) {
 	const ids = new Set(await loadCollapsed());
 
@@ -225,7 +238,11 @@
 		const days = Math.floor(hours / 24);
 
 		return days === 1 ? "1 day ago" : days + " days ago";
-	}
+  }
+
+  function isNewComment(comment, seenTimestamp) {
+    return comment.time && comment.time > seenTimestamp;
+  }
 
 	function isMobile() {
 		return window.matchMedia("(max-width: 700px)").matches;
@@ -577,6 +594,11 @@ header button {
     overflow-wrap:anywhere;
 }
 
+.comment.new-comment {
+	border-left:2px solid #ff6600;
+	padding-left:6px;
+}
+
 .top-level-comments > .comment {
     margin-left:0;
 }
@@ -874,23 +896,23 @@ add comment
 	// Comment rendering
 	// -------------------------
 
-	async function renderComment(id, container, storyID, storyAuthor) {
+	async function renderComment(id, container, storyID, storyAuthor, seenTime = 0) {
 		const comment = await getItem(id);
 
 		if (!comment || comment.deleted || comment.dead) return;
-
 		const div = document.createElement("div");
 
-		div.className = "comment";
+    div.className = "comment";
+
+    if (isNewComment(comment, seenTime)) {
+	div.classList.add("new-comment");
+    }
 
 		const replies = comment.kids || [];
-
 		const reply = replyURL(comment, storyID);
 
 		div.innerHTML = `
-
 <div class="meta">
-
 
 <a target="_blank"
 href="https://news.ycombinator.com/user?id=${encodeURIComponent(comment.by || "")}">
@@ -977,9 +999,11 @@ ${sanitizeHTML(comment.text) || ""}
 		comments.className = "top-level-comments";
 		ui.body.appendChild(comments);
 
+		const seenTime = await getSeenTime(story.id);
 		for (const child of story.kids || []) {
-		  await renderComment(child, comments, story.id, story.by);
+			await renderComment(child, comments, story.id, story.by, seenTime);
 		}
+		await markSeen(story.id);
 	}
 
 	async function renderBlendedDiscussion(stories, ui) {
@@ -1001,9 +1025,11 @@ ${sanitizeHTML(comment.text) || ""}
 
 			section.appendChild(comments);
 
+			const seenTime = await getSeenTime(story.id);
 			for (const child of story.kids || []) {
-			  await renderComment(child, comments, story.id, story.by);
+				await renderComment(child, comments, story.id, story.by, seenTime);
 			}
+			await markSeen(story.id);
 		}
 	}
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -390,6 +390,19 @@
         -webkit-tap-highlight-color: transparent;
     `;
 
+		if (isMobile()) {
+			button.style.width = "44px";
+			button.style.height = "44px";
+			button.style.padding = "0";
+			button.style.borderRadius = "50%";
+			button.style.display = "flex";
+			button.style.alignItems = "center";
+			button.style.justifyContent = "center";
+			button.style.fontSize = "13px";
+			button.style.top = "16px";
+			button.style.right = "16px";
+		}
+
 		document.body.appendChild(button);
 
 		await applyButtonPosition(button);
@@ -425,6 +438,19 @@
 			touch-action:none;
 			-webkit-tap-highlight-color: transparent;
 		`;
+
+		if (isMobile()) {
+			button.style.width = "44px";
+			button.style.height = "44px";
+			button.style.padding = "0";
+			button.style.borderRadius = "50%";
+			button.style.display = "flex";
+			button.style.alignItems = "center";
+			button.style.justifyContent = "center";
+			button.style.fontSize = "13px";
+			button.style.top = "16px";
+			button.style.right = "16px";
+		}
 
 		document.body.appendChild(button);
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HNewhere
 // @namespace    https://github.com/twalichiewicz/HNewhere
-// @version      1.4.6
+// @version      1.4.7
 // @updateURL    https://raw.githubusercontent.com/twalichiewicz/HNewhere/main/HNewhere.user.js
 // @downloadURL  https://raw.githubusercontent.com/twalichiewicz/HNewhere/main/HNewhere.user.js
 // @homepageURL  https://github.com/twalichiewicz/HNewhere

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -101,11 +101,13 @@
 	// -------------------------
 
 	function request(url) {
-		return new Promise((resolve, reject) => {
+		return new Promise((resolve) => {
 			GM.xmlHttpRequest({
 				method: "GET",
 
 				url: url,
+
+				timeout: 10000,
 
 				onload: function (response) {
 					try {
@@ -116,6 +118,10 @@
 				},
 
 				onerror: function () {
+					resolve(null);
+				},
+
+				ontimeout: function () {
 					resolve(null);
 				},
 			});

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -39,6 +39,8 @@
 		width: "hn_width",
 		position: "hn_button_position",
 		last: "hn_last",
+		collapsed: "hn_collapsed_comments",
+		seen: "hn_seen_comments",
 	};
 
 	let sidebar = null;
@@ -58,7 +60,27 @@
 		} catch {
 			return fallback;
 		}
+  }
+
+  async function loadCollapsed() {
+	return await load(STORAGE.collapsed, []);
+  }
+
+  async function saveCollapsed(ids) {
+	await save(STORAGE.collapsed, ids);
+  }
+
+  async function toggleCollapsed(id, collapsed) {
+	const ids = new Set(await loadCollapsed());
+
+	if (collapsed) {
+		ids.add(id);
+	} else {
+		ids.delete(id);
 	}
+
+	await saveCollapsed([...ids]);
+  }
 
 	// -------------------------
 	// Network
@@ -907,15 +929,22 @@ ${sanitizeHTML(comment.text) || ""}
 		container.appendChild(div);
 
 		const children = div.querySelector(".children");
-
 		const toggle = div.querySelector(".toggle");
+		const collapsed = await loadCollapsed();
 
-		toggle.onclick = () => {
-			children.classList.toggle("hidden");
+		if (collapsed.includes(comment.id)) {
+			children.classList.add("hidden");
+			toggle.textContent = "[+]";
+		}
 
-			toggle.textContent = children.classList.contains("hidden")
+		toggle.onclick = async () => {
+			const hidden = children.classList.toggle("hidden");
+
+			toggle.textContent = hidden
 				? "[+]"
 				: "[–]";
+
+			await toggleCollapsed(comment.id, hidden);
 		};
 
 		const replyButton = div.querySelector(".reply-link");

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -514,8 +514,11 @@ header button {
 }
 
 #comments {
+	flex:1 1 auto;
+	min-height:0;
     overflow:auto;
     overflow-x:hidden;
+	overscroll-behavior:contain;
     padding:8px 12px;
     word-wrap:break-word;
 }
@@ -615,6 +618,12 @@ Loading...
 `;
 
 		const panel = shadow.querySelector("#panel");
+
+		// Stop scroll/touch events moving out of sidebar so sites with
+		// JS scroll hijacking (wheel listeners on window) don't scroll behind
+		for (const type of ["wheel", "touchmove"]) {
+		  host.addEventListener(type, (event) => event.stopPropagation());
+		}
 
 		let resizing = false;
 		let startX = 0;

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -13,7 +13,8 @@
 // @exclude https://localhost/*
 // @exclude      https://www.google.com/*
 // @exclude      https://www.google.*/*
-// @exclude      https://chatgpt.com/*
+// @exclude      https://chatgpt.com/
+// @exclude      https://claude.ai/
 // @exclude      https://*.google.com/*
 // @exclude      https://accounts.google.com/*
 // @exclude      https://mail.google.com/*
@@ -35,6 +36,34 @@
 (function () {
 	"use strict";
 
+	const OLD_STORAGE = {
+		width: "hn_width",
+		position: "hn_button_position",
+		last: "hn_last",
+		collapsed: "hn_collapsed_comments",
+		seen: "hn_seen_comments",
+	};
+
+	async function migrateStorage() {
+		const migrated = await load("HNewhere:migrated", false);
+
+		if (migrated) return;
+
+		try {
+			for (const key of Object.keys(STORAGE)) {
+				const oldValue = await load(OLD_STORAGE[key], null);
+
+				if (oldValue !== null) {
+					await save(STORAGE[key], oldValue);
+				}
+			}
+
+			await save("HNewhere:migrated", 1);
+		} catch (e) {
+			console.error("HNewhere migration failed:", e);
+		}
+	}
+
 	const STORAGE = {
 		width: "HNewhere:width",
 		position: "HNewhere:button_position",
@@ -45,6 +74,7 @@
 
 	let sidebar = null;
 	let opening = false;
+	let sidebarGeneration = 0;
 
 	// -------------------------
 	// Storage
@@ -128,14 +158,36 @@
 		});
 	}
 
+	const itemCache = new Map();
+
 	async function getItem(id) {
-		return request(
+		if (itemCache.has(id)) {
+			return itemCache.get(id);
+		}
+
+		const item = await request(
 			"https://hacker-news.firebaseio.com/v0/item/" + id + ".json",
 		);
+
+		itemCache.set(id, item);
+
+		return item;
 	}
 
 	async function findHN(url) {
 		const target = normalizeURL(url);
+
+		if (!target) {
+			return [];
+		}
+
+		const cacheKey = "HNewhere:hn_cache:" + target;
+
+		const cached = await load(cacheKey, null);
+
+		if (cached && Date.now() - cached.timestamp < 3600000) {
+			return cached.results;
+		}
 
 		const queries = [url, target];
 
@@ -143,22 +195,31 @@
 
 		for (const query of queries) {
 			const result = await request(
-				"https://hn.algolia.com/api/v1/search?tags=story&restrictSearchableAttributes=url&hitsPerPage=100&query=" +
+				"https://hn.algolia.com/api/v1/search?tags=story&restrictSearchableAttributes=url&hitsPerPage=20&query=" +
 					encodeURIComponent(query),
 			);
 
-			if (!result || !result.hits) continue;
+			if (!result || !result.hits) {
+				continue;
+			}
 
-			result.hits.forEach((item) => {
+			for (const item of result.hits) {
 				if (normalizeURL(item.url) === target) {
 					matches.set(item.objectID, item);
 				}
-			});
+			}
 		}
 
-		return [...matches.values()].sort(
+		const sorted = [...matches.values()].sort(
 			(a, b) => b.created_at_i - a.created_at_i,
 		);
+
+		await save(cacheKey, {
+			timestamp: Date.now(),
+			results: sorted,
+		});
+
+		return sorted;
 	}
 
 	// -------------------------
@@ -204,33 +265,66 @@
 			"EM",
 			"BLOCKQUOTE",
 			"BR",
+			"TT",
+			"UL",
+			"OL",
+			"LI",
+			"HR",
 		]);
 
-		const allowedAttributes = new Set(["href"]);
-
-		template.content.querySelectorAll("*").forEach((el) => {
-			if (!allowedTags.has(el.tagName)) {
-				el.replaceWith(...el.childNodes);
-				return;
-			}
-
-			for (const attr of [...el.attributes]) {
-				if (!allowedAttributes.has(attr.name.toLowerCase())) {
-					el.removeAttribute(attr.name);
-				}
-			}
-
-			if (el.tagName === "A") {
-				const href = el.getAttribute("href");
-
-				if (!href || !/^(https?:\/\/|\/)/i.test(href)) {
-					el.removeAttribute("href");
+		function cleanNode(node) {
+			for (const child of [...node.childNodes]) {
+				if (child.nodeType !== Node.ELEMENT_NODE) {
+					continue;
 				}
 
-				el.setAttribute("target", "_blank");
-				el.setAttribute("rel", "noopener noreferrer");
+				if (!allowedTags.has(child.tagName)) {
+					const fragment = document.createDocumentFragment();
+
+					while (child.firstChild) {
+						fragment.appendChild(child.firstChild);
+					}
+
+					child.replaceWith(fragment);
+					continue;
+				}
+
+				const originalText = child.textContent;
+
+				let safeHref = null;
+
+				if (child.tagName === "A") {
+					const href = child.getAttribute("href");
+
+					try {
+						const url = new URL(href, location.origin);
+
+						if (url.protocol !== "http:" && url.protocol !== "https:") {
+							throw new Error();
+						}
+
+						safeHref = url.href;
+					} catch {
+						child.replaceWith(document.createTextNode(originalText));
+						continue;
+					}
+				}
+
+				for (const attr of [...child.attributes]) {
+					child.removeAttribute(attr.name);
+				}
+
+				if (safeHref) {
+					child.setAttribute("href", safeHref);
+					child.setAttribute("target", "_blank");
+					child.setAttribute("rel", "noopener noreferrer");
+				}
+
+				cleanNode(child);
 			}
-		});
+		}
+
+		cleanNode(template.content);
 
 		return template.innerHTML;
 	}
@@ -270,21 +364,6 @@
 
 	function isMobile() {
 		return window.matchMedia("(max-width: 700px)").matches;
-	}
-
-	function clampButtonPosition(button) {
-		const maxX = window.innerWidth - button.offsetWidth;
-		const maxY = window.innerHeight - button.offsetHeight;
-
-		const currentX = parseInt(button.style.left || button.offsetLeft, 10);
-		const currentY = parseInt(button.style.top || button.offsetTop, 10);
-
-		const x = Math.max(0, Math.min(currentX, maxX));
-		const y = Math.max(0, Math.min(currentY, maxY));
-
-		button.style.left = x + "px";
-		button.style.top = y + "px";
-		button.style.right = "auto";
 	}
 
 	// -------------------------
@@ -429,6 +508,7 @@
 
 	async function createRestoreButton() {
 		let button = document.getElementById("hn-restore-button");
+
 		if (button) return button;
 
 		button = document.createElement("button");
@@ -436,40 +516,55 @@
 		button.textContent = "HN";
 
 		button.style.cssText = `
-        position:fixed;
-        top:12px;
-        right:12px;
-        z-index:2147483647;
-        background:#ff6600;
-        color:white;
-        border:none;
-        border-radius:3px;
-        padding:4px 8px;
-        font-family:Verdana,sans-serif;
-        font-size:11px;
-        font-weight:bold;
-        cursor:pointer;
-        box-shadow:0 1px 4px rgba(0,0,0,.25);
-        -webkit-tap-highlight-color: transparent;
-    `;
+			position:fixed;
+			top:12px;
+			right:12px;
+			z-index:2147483647;
+			background:#ff6600;
+			color:white;
+			border:none;
+			border-radius:3px;
+			padding:4px 8px;
+			font-family:Verdana,sans-serif;
+			font-size:11px;
+			font-weight:bold;
+			cursor:pointer;
+			box-shadow:0 1px 4px rgba(0,0,0,.25);
+			user-select:none;
+			touch-action:none;
+			-webkit-tap-highlight-color:transparent;
+		`;
 
 		if (isMobile()) {
-			button.style.width = "44px";
-			button.style.height = "44px";
-			button.style.padding = "0";
-			button.style.borderRadius = "50%";
-			button.style.display = "flex";
-			button.style.alignItems = "center";
-			button.style.justifyContent = "center";
-			button.style.fontSize = "13px";
-			button.style.top = "16px";
-			button.style.right = "16px";
+			Object.assign(button.style, {
+				width: "44px",
+				height: "44px",
+				padding: "0",
+				borderRadius: "50%",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				fontSize: "13px",
+				top: "16px",
+				right: "16px",
+			});
 		}
 
 		document.body.appendChild(button);
 
 		await applyButtonPosition(button);
-		makeButtonDraggable(button);
+
+		const wasMoved = makeButtonDraggable(button);
+
+		button.onclick = () => {
+			if (wasMoved()) return;
+
+			if (sidebar) {
+				sidebar.style.display = "";
+			}
+
+			button.remove();
+		};
 
 		return button;
 	}
@@ -573,12 +668,6 @@
     box-shadow:-3px 0 12px rgba(0,0,0,.15);
     font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     font-size:13px;
-}
-
-.load-replies {
-	cursor:pointer;
-	color:#828282;
-	font-size:10px;
 }
 
 header {
@@ -830,11 +919,23 @@ Loading...
 
 		let destroyed = false;
 
+		const clampSidebarWidth = () => {
+			const maxWidth = window.innerWidth * 0.8;
+
+			if (panel.offsetWidth > maxWidth) {
+				panel.style.width = maxWidth + "px";
+				save(STORAGE.width, maxWidth);
+			}
+		};
+
+		window.addEventListener("resize", clampSidebarWidth);
+
 		host._cleanup = () => {
 			destroyed = true;
 			clearTimeout(resizeTimer);
 			document.removeEventListener("mousemove", onMouseMove);
 			document.removeEventListener("mouseup", onMouseUp);
+			window.removeEventListener("resize", clampSidebarWidth);
 		};
 
 		shadow.querySelector("#minimize").onclick = async () => {
@@ -865,7 +966,9 @@ Loading...
 	// -------------------------
 
 	function renderStory(story, container, options = {}) {
-		const { multiple = false, stories = [] } = options;
+		if (!story?.id) {
+			return;
+		}
 
 		const hnURL = commentURL(story.id);
 
@@ -942,24 +1045,28 @@ add comment
 		storyAuthor,
 		seenTime,
 		collapsedIds,
+		generation = sidebarGeneration,
 	) {
-		let rendered = 0;
+		const batchSize = 5;
 
-		for (const replyID of replyIDs) {
-			await renderComment(
-				replyID,
-				container,
-				storyID,
-				storyAuthor,
-				seenTime,
-				collapsedIds,
+		for (let i = 0; i < replyIDs.length; i += batchSize) {
+			const batch = replyIDs.slice(i, i + batchSize);
+
+			await Promise.all(
+				batch.map((id) =>
+					renderComment(
+						id,
+						container,
+						storyID,
+						storyAuthor,
+						seenTime,
+						collapsedIds,
+						generation,
+					),
+				),
 			);
 
-			rendered++;
-
-			if (rendered % 10 === 0) {
-				await new Promise(requestAnimationFrame);
-			}
+			await new Promise(requestAnimationFrame);
 		}
 	}
 
@@ -970,8 +1077,13 @@ add comment
 		storyAuthor,
 		seenTime = 0,
 		collapsedIds = new Set(),
+		generation = sidebarGeneration,
 	) {
 		const comment = await getItem(id);
+
+		if (generation !== sidebarGeneration) {
+			return;
+		}
 
 		if (!comment || comment.deleted || comment.dead) return;
 		const div = document.createElement("div");
@@ -1056,6 +1168,7 @@ add comment
 				storyAuthor,
 				seenTime,
 				collapsedIds,
+				generation,
 			);
 		}
 	}
@@ -1076,16 +1189,15 @@ add comment
 		const seenTime = await getSeenTime(story.id);
 		const collapsedIds = await loadCollapsed();
 
-		for (const child of story.kids || []) {
-			await renderComment(
-				child,
-				comments,
-				story.id,
-				story.by,
-				seenTime,
-				collapsedIds,
-			);
-		}
+		await renderChildren(
+			story.kids || [],
+			comments,
+			story.id,
+			story.by,
+			seenTime,
+			collapsedIds,
+		);
+
 		await markSeen(story.id);
 	}
 
@@ -1111,33 +1223,33 @@ add comment
 			const seenTime = await getSeenTime(story.id);
 			const collapsedIds = await loadCollapsed();
 
-			for (const child of story.kids || []) {
-				await renderComment(
-					child,
-					comments,
-					story.id,
-					story.by,
-					seenTime,
-					collapsedIds,
-				);
-			}
+			await renderChildren(
+				story.kids || [],
+				comments,
+				story.id,
+				story.by,
+				seenTime,
+				collapsedIds,
+			);
+
 			await markSeen(story.id);
 		}
 	}
 
 	async function loadStories(stories) {
-		const loaded = [];
+		const ids = [
+			...new Set(
+				normalizeStories(stories)
+					.map((story) => story.objectID)
+					.filter(Boolean),
+			),
+		];
 
-		for (const story of normalizeStories(stories)) {
-			const item = await getItem(story.objectID);
+		const items = await Promise.all(ids.map((id) => getItem(id)));
 
-			if (item) {
-				loaded.push(item);
-			}
-		}
-
-		loaded.sort((a, b) => b.time - a.time);
-		return loaded;
+		return items
+			.filter((item) => item && item.type === "story")
+			.sort((a, b) => b.time - a.time);
 	}
 
 	// -------------------------
@@ -1161,11 +1273,13 @@ add comment
 				throw new Error("No HN stories could be loaded");
 			}
 
+			const generation = ++sidebarGeneration;
 			const ui = await createSidebar();
 
-			if (!loaded.length) {
-				throw new Error("No HN stories could be loaded");
+			if (generation !== sidebarGeneration) {
+				return;
 			}
+
 			if (loaded.length === 1) {
 				await renderSingleDiscussion(loaded[0], ui);
 			} else {
@@ -1187,19 +1301,17 @@ add comment
 			"click",
 			async function (event) {
 				try {
-					const link = event.target.closest("a");
-					if (!link) return;
-					const row = link.closest("tr.athing");
-					if (!row) return;
-					if (!link.closest(".titleline")) return;
-					const id = row.id;
-					if (!id) return;
+					const link = event.target.closest(".titleline > a");
 
-					console.log("Saving HN story:", id, link.href);
+					if (!link) return;
+
+					const row = link.closest("tr.athing");
+
+					if (!row?.id) return;
 
 					await save(STORAGE.last, {
 						url: link.href,
-						ids: [id],
+						ids: [row.id],
 						timestamp: Date.now(),
 					});
 				} catch (e) {
@@ -1223,7 +1335,7 @@ add comment
 	// -------------------------
 
 	async function init() {
-		console.log("HNewhere sidebar loaded", location.href);
+		await migrateStorage();
 
 		// On HN, only record clicked stories.
 		if (location.hostname === "news.ycombinator.com") {
@@ -1240,18 +1352,11 @@ add comment
 			last = null;
 		}
 
-		console.log("Stored HN click:", last);
-		console.log("Current URL:", location.href);
-		console.log("Same URL:", last && sameURL(last.url, location.href));
-		console.log("Age:", last ? Date.now() - last.timestamp : null);
-
 		if (
 			last &&
 			sameURL(last.url, location.href) &&
 			Date.now() - last.timestamp < 300000
 		) {
-			console.log("Opening HN discussion from click:", last.ids);
-
 			await save(STORAGE.last, null);
 
 			await openSidebar(
@@ -1268,11 +1373,6 @@ add comment
 		const stories = await findHN(location.href);
 
 		if (stories.length) {
-			console.log(
-				"Found HN discussions:",
-				stories.map((s) => s.objectID),
-			);
-
 			if (isMobile()) {
 				await createCollapsedButton(stories);
 			} else {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -610,6 +610,23 @@ header button {
     line-height:1.4;
 }
 
+.story-text {
+    margin:10px 0;
+    line-height:1.45;
+}
+
+.story-text p:first-child {
+    margin-top:0;
+}
+
+.story-text p:last-child {
+    margin-bottom:0;
+}
+
+.story-text a {
+    color:#0000aa;
+}
+
 .story-actions {
     margin-top:8px;
 }
@@ -784,7 +801,18 @@ ${escapeHTML(story.by || "")}
 |
 
 ${timeAgo(story.time)}
+
+|
+
+${story.descendants || 0} comments
+
 </div>
+
+${story.text ? `
+<div class="story-text">
+${sanitizeHTML(story.text)}
+</div>
+` : ""}
 
 <div class="story-actions">
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -945,6 +945,8 @@ add comment
 		seenTime,
 		collapsedIds,
 	) {
+		let rendered = 0;
+
 		for (const replyID of replyIDs) {
 			await renderComment(
 				replyID,
@@ -954,6 +956,12 @@ add comment
 				seenTime,
 				collapsedIds,
 			);
+
+			rendered++;
+
+			if (rendered % 10 === 0) {
+				await new Promise(requestAnimationFrame);
+			}
 		}
 	}
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -188,7 +188,9 @@
 		template.innerHTML = html || "";
 
 		template.content
-			.querySelectorAll("script, iframe, object, embed")
+			.querySelectorAll(
+				"script, iframe, object, embed, form, input, button, textarea, select, svg, math",
+			)
 			.forEach((el) => el.remove());
 
 		template.content.querySelectorAll("*").forEach((el) => {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -60,40 +60,41 @@
 		} catch {
 			return fallback;
 		}
-  }
-
-  async function loadCollapsed() {
-	return await load(STORAGE.collapsed, []);
-  }
-
-  async function saveCollapsed(ids) {
-	await save(STORAGE.collapsed, ids);
-  }
-
-  async function getSeenTime(storyID) {
-	const seen = await load(STORAGE.seen, {});
-	return seen[storyID] || 0;
-  }
-
-  async function markSeen(storyID) {
-	const seen = await load(STORAGE.seen, {});
-
-	seen[storyID] = Math.floor(Date.now() / 1000);
-
-	await save(STORAGE.seen, seen);
-  }
-
-  async function toggleCollapsed(id, collapsed) {
-	const ids = new Set(await loadCollapsed());
-
-	if (collapsed) {
-		ids.add(id);
-	} else {
-		ids.delete(id);
 	}
 
-	await saveCollapsed([...ids]);
-  }
+	async function loadCollapsed() {
+		const ids = await load(STORAGE.collapsed, []);
+		return new Set(Array.isArray(ids) ? ids : []);
+	}
+
+	async function saveCollapsed(ids) {
+		await save(STORAGE.collapsed, ids);
+	}
+
+	async function getSeenTime(storyID) {
+		const seen = await load(STORAGE.seen, {});
+		return seen[storyID] || 0;
+	}
+
+	async function markSeen(storyID) {
+		const seen = await load(STORAGE.seen, {});
+
+		seen[storyID] = Math.floor(Date.now() / 1000);
+
+		await save(STORAGE.seen, seen);
+	}
+
+	async function toggleCollapsed(id, collapsed) {
+		const ids = new Set(await loadCollapsed());
+
+		if (collapsed) {
+			ids.add(id);
+		} else {
+			ids.delete(id);
+		}
+
+		await saveCollapsed([...ids]);
+	}
 
 	// -------------------------
 	// Network
@@ -238,11 +239,11 @@
 		const days = Math.floor(hours / 24);
 
 		return days === 1 ? "1 day ago" : days + " days ago";
-  }
+	}
 
-  function isNewComment(comment, seenTimestamp) {
-    return comment.time && comment.time > seenTimestamp;
-  }
+	function isNewComment(comment, seenTimestamp) {
+		return comment.time && comment.time > seenTimestamp;
+	}
 
 	function isMobile() {
 		return window.matchMedia("(max-width: 700px)").matches;
@@ -551,6 +552,12 @@
     font-size:13px;
 }
 
+.load-replies {
+	cursor:pointer;
+	color:#828282;
+	font-size:10px;
+}
+
 header {
     background:#ff6600;
     color:black;
@@ -589,18 +596,23 @@ header button {
 }
 
 .comment {
-    margin:12px 0 12px 15px;
+    margin:12px 0 12px 18px;
     max-width:100%;
     overflow-wrap:anywhere;
+}
+
+.top-level-comments > .comment {
+    margin-left:0;
+}
+
+.children > .comment {
+    border-left:1px solid #ddd;
+    padding-left:8px;
 }
 
 .comment.new-comment {
 	border-left:2px solid #ff6600;
 	padding-left:6px;
-}
-
-.top-level-comments > .comment {
-    margin-left:0;
 }
 
 .text {
@@ -722,7 +734,7 @@ Loading...
 		// Stop scroll/touch events moving out of sidebar so sites with
 		// JS scroll hijacking (wheel listeners on window) don't scroll behind
 		for (const type of ["wheel", "touchmove"]) {
-		  host.addEventListener(type, (event) => event.stopPropagation());
+			host.addEventListener(type, (event) => event.stopPropagation());
 		}
 
 		let resizing = false;
@@ -866,11 +878,15 @@ ${story.descendants || 0} comments
 
 </div>
 
-${story.text ? `
+${
+	story.text
+		? `
 <div class="story-text">
 ${sanitizeHTML(story.text)}
 </div>
-` : ""}
+`
+		: ""
+}
 
 <div class="story-actions">
 
@@ -896,65 +912,91 @@ add comment
 	// Comment rendering
 	// -------------------------
 
-	async function renderComment(id, container, storyID, storyAuthor, seenTime = 0) {
+	async function renderChildren(
+		replyIDs,
+		container,
+		storyID,
+		storyAuthor,
+		seenTime,
+		collapsedIds,
+	) {
+		for (const replyID of replyIDs) {
+			await renderComment(
+				replyID,
+				container,
+				storyID,
+				storyAuthor,
+				seenTime,
+				collapsedIds,
+			);
+		}
+	}
+
+	async function renderComment(
+		id,
+		container,
+		storyID,
+		storyAuthor,
+		seenTime = 0,
+		collapsedIds = new Set(),
+	) {
 		const comment = await getItem(id);
 
 		if (!comment || comment.deleted || comment.dead) return;
 		const div = document.createElement("div");
 
-    div.className = "comment";
+		div.className = "comment";
 
-    if (isNewComment(comment, seenTime)) {
-	div.classList.add("new-comment");
-    }
+		if (isNewComment(comment, seenTime)) {
+			div.classList.add("new-comment");
+		}
 
 		const replies = comment.kids || [];
 		const reply = replyURL(comment, storyID);
 
 		div.innerHTML = `
-<div class="meta">
+      <div class="meta">
 
-<a target="_blank"
-href="https://news.ycombinator.com/user?id=${encodeURIComponent(comment.by || "")}">
+      <a target="_blank"
+      href="https://news.ycombinator.com/user?id=${encodeURIComponent(comment.by || "")}">
 
-${escapeHTML(comment.by || "anonymous")}
+      ${escapeHTML(comment.by || "anonymous")}
 
-</a>
+      </a>
 
-${comment.by && comment.by === storyAuthor
-	? `<span class="op-pill">OP</span>`
-	: ""}
+      ${
+				comment.by && comment.by === storyAuthor
+					? `<span class="op-pill">OP</span>`
+					: ""
+			}
 
+      ${timeAgo(comment.time)}
 
-${timeAgo(comment.time)}
+      |
 
-|
+      <a class="reply-link" href="#">
+      reply
+      </a>
 
-<a class="reply-link"
-href="#">
-reply
-</a>
+      <span class="toggle">
+      [–]
+      </span>
 
-<span class="toggle">
-[–]
-</span>
-</div>
+      </div>
 
-<div class="text">
-<div class="children">
-${sanitizeHTML(comment.text) || ""}
-</div>
-</div>
+      <div class="text">
+     	${sanitizeHTML(comment.text) || ""}
+      </div>
 
-`;
+      <div class="children"></div>
+    `;
 
 		container.appendChild(div);
 
 		const children = div.querySelector(".children");
 		const toggle = div.querySelector(".toggle");
-		const collapsed = await loadCollapsed();
 
-		if (collapsed.includes(comment.id)) {
+		if (collapsedIds.has(comment.id)) {
 			children.classList.add("hidden");
 			toggle.textContent = "[+]";
 		}
@@ -962,9 +1004,7 @@ ${sanitizeHTML(comment.text) || ""}
 		toggle.onclick = async () => {
 			const hidden = children.classList.toggle("hidden");
 
-			toggle.textContent = hidden
-				? "[+]"
-				: "[–]";
+			toggle.textContent = hidden ? "[+]" : "[–]";
 
 			await toggleCollapsed(comment.id, hidden);
 		};
@@ -977,12 +1017,15 @@ ${sanitizeHTML(comment.text) || ""}
 			openHNWindow(reply);
 		};
 
-		for (let i = 0; i < replies.length; i++) {
-		  await renderComment(replies[i], children, storyID, storyAuthor);
-
-			if (i > 0 && i % 10 === 0) {
-				await new Promise(requestAnimationFrame);
-			}
+		if (replies.length) {
+			await renderChildren(
+				replies,
+				children,
+				storyID,
+				storyAuthor,
+				seenTime,
+				collapsedIds,
+			);
 		}
 	}
 
@@ -1000,8 +1043,17 @@ ${sanitizeHTML(comment.text) || ""}
 		ui.body.appendChild(comments);
 
 		const seenTime = await getSeenTime(story.id);
+		const collapsedIds = await loadCollapsed();
+
 		for (const child of story.kids || []) {
-			await renderComment(child, comments, story.id, story.by, seenTime);
+			await renderComment(
+				child,
+				comments,
+				story.id,
+				story.by,
+				seenTime,
+				collapsedIds,
+			);
 		}
 		await markSeen(story.id);
 	}
@@ -1026,8 +1078,17 @@ ${sanitizeHTML(comment.text) || ""}
 			section.appendChild(comments);
 
 			const seenTime = await getSeenTime(story.id);
+			const collapsedIds = await loadCollapsed();
+
 			for (const child of story.kids || []) {
-				await renderComment(child, comments, story.id, story.by, seenTime);
+				await renderComment(
+					child,
+					comments,
+					story.id,
+					story.by,
+					seenTime,
+					collapsedIds,
+				);
 			}
 			await markSeen(story.id);
 		}

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -187,27 +187,44 @@
 		const template = document.createElement("template");
 		template.innerHTML = html || "";
 
-		template.content
-			.querySelectorAll(
-				"script, iframe, object, embed, form, input, button, textarea, select, svg, math",
-			)
-			.forEach((el) => el.remove());
+		const allowedTags = new Set([
+			"A",
+			"P",
+			"PRE",
+			"CODE",
+			"B",
+			"STRONG",
+			"I",
+			"EM",
+			"BLOCKQUOTE",
+			"BR",
+		]);
+
+		const allowedAttributes = new Set([
+			"href",
+		]);
 
 		template.content.querySelectorAll("*").forEach((el) => {
+			if (!allowedTags.has(el.tagName)) {
+				el.replaceWith(...el.childNodes);
+				return;
+			}
+
 			for (const attr of [...el.attributes]) {
-				if (attr.name.startsWith("on")) {
+				if (!allowedAttributes.has(attr.name.toLowerCase())) {
 					el.removeAttribute(attr.name);
 				}
 			}
 
-			el.removeAttribute("style");
+			if (el.tagName === "A") {
+				const href = el.getAttribute("href");
 
-			for (const attr of ["href", "src"]) {
-				const value = el.getAttribute(attr);
-
-				if (value && /^(javascript|data):/i.test(value)) {
-					el.removeAttribute(attr);
+				if (!href || !/^(https?:\/\/|\/)/i.test(href)) {
+					el.removeAttribute("href");
 				}
+
+				el.setAttribute("target", "_blank");
+				el.setAttribute("rel", "noopener noreferrer");
 			}
 		});
 
@@ -1126,13 +1143,13 @@ add comment
 		opening = true;
 
 		try {
-		const loaded = await loadStories(stories);
+			const loaded = await loadStories(stories);
 
-		if (!loaded.length) {
-			throw new Error("No HN stories could be loaded");
-		}
+			if (!loaded.length) {
+				throw new Error("No HN stories could be loaded");
+			}
 
-		const ui = await createSidebar();
+			const ui = await createSidebar();
 
 			if (!loaded.length) {
 				throw new Error("No HN stories could be loaded");

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -1127,25 +1127,26 @@ add comment
 
       </div>
 
-      <div class="text">
-     	${sanitizeHTML(comment.text) || ""}
+      <div class="comment-content">
+       	<div class="text">
+        		${sanitizeHTML(comment.text) || ""}
+       	</div>
+       	<div class="children"></div>
       </div>
-
-      <div class="children"></div>
     `;
 
 		container.appendChild(div);
 
-		const children = div.querySelector(".children");
+		const content = div.querySelector(".comment-content");
 		const toggle = div.querySelector(".toggle");
 
 		if (collapsedIds.has(comment.id)) {
-			children.classList.add("hidden");
+			content.classList.add("hidden");
 			toggle.textContent = "[+]";
 		}
 
 		toggle.onclick = async () => {
-			const hidden = children.classList.toggle("hidden");
+			const hidden = content.classList.toggle("hidden");
 
 			toggle.textContent = hidden ? "[+]" : "[–]";
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -1138,6 +1138,7 @@ add comment
 		container.appendChild(div);
 
 		const content = div.querySelector(".comment-content");
+		const children = div.querySelector(".children");
 		const toggle = div.querySelector(".toggle");
 
 		if (collapsedIds.has(comment.id)) {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -775,7 +775,7 @@ Loading...
 	function renderStory(story, container, options = {}) {
 		const { multiple = false, stories = [] } = options;
 
-		const url = story.url || "https://news.ycombinator.com/item?id=" + story.id;
+		const hnURL = commentURL(story.id);
 
 		const wrapper = document.createElement("div");
 		wrapper.innerHTML = `
@@ -785,7 +785,8 @@ Loading...
 <div class="story-title">
 
 <a target="_blank"
-href="${escapeHTML(url)}">
+href="${escapeHTML(hnURL)}"
+title="Open discussion on Hacker News">
 
 ${escapeHTML(story.title)}
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -36,11 +36,11 @@
 	"use strict";
 
 	const STORAGE = {
-		width: "hn_width",
-		position: "hn_button_position",
-		last: "hn_last",
-		collapsed: "hn_collapsed_comments",
-		seen: "hn_seen_comments",
+		width: "HNewhere:width",
+		position: "HNewhere:button_position",
+		last: "HNewhere:last",
+		collapsed: "HNewhere:collapsed_comments",
+		seen: "HNewhere:seen_comments",
 	};
 
 	let sidebar = null;

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -587,6 +587,19 @@ header button {
     text-decoration:underline;
 }
 
+.op-pill {
+    display:inline-block;
+    margin-left:4px;
+    margin-right:4px;
+    padding:1px 4px;
+    border-radius:3px;
+    background:#ff6600;
+    color:white;
+    font-size:9px;
+    font-weight:bold;
+    line-height:1.2;
+}
+
 .toggle {
     cursor:pointer;
 }
@@ -839,7 +852,7 @@ add comment
 	// Comment rendering
 	// -------------------------
 
-	async function renderComment(id, container, storyID) {
+	async function renderComment(id, container, storyID, storyAuthor) {
 		const comment = await getItem(id);
 
 		if (!comment || comment.deleted || comment.dead) return;
@@ -863,6 +876,10 @@ href="https://news.ycombinator.com/user?id=${encodeURIComponent(comment.by || ""
 ${escapeHTML(comment.by || "anonymous")}
 
 </a>
+
+${comment.by && comment.by === storyAuthor
+	? `<span class="op-pill">OP</span>`
+	: ""}
 
 
 ${timeAgo(comment.time)}
@@ -910,7 +927,7 @@ ${sanitizeHTML(comment.text) || ""}
 		};
 
 		for (let i = 0; i < replies.length; i++) {
-			await renderComment(replies[i], children, storyID);
+		  await renderComment(replies[i], children, storyID, storyAuthor);
 
 			if (i > 0 && i % 10 === 0) {
 				await new Promise(requestAnimationFrame);
@@ -932,7 +949,7 @@ ${sanitizeHTML(comment.text) || ""}
 		ui.body.appendChild(comments);
 
 		for (const child of story.kids || []) {
-			await renderComment(child, comments, story.id);
+		  await renderComment(child, comments, story.id, story.by);
 		}
 	}
 
@@ -956,7 +973,7 @@ ${sanitizeHTML(comment.text) || ""}
 			section.appendChild(comments);
 
 			for (const child of story.kids || []) {
-				await renderComment(child, comments, story.id);
+			  await renderComment(child, comments, story.id, story.by);
 			}
 		}
 	}

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -1126,9 +1126,13 @@ add comment
 		opening = true;
 
 		try {
-			const ui = await createSidebar();
+		const loaded = await loadStories(stories);
 
-			const loaded = await loadStories(stories);
+		if (!loaded.length) {
+			throw new Error("No HN stories could be loaded");
+		}
+
+		const ui = await createSidebar();
 
 			if (!loaded.length) {
 				throw new Error("No HN stories could be loaded");

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -206,9 +206,7 @@
 			"BR",
 		]);
 
-		const allowedAttributes = new Set([
-			"href",
-		]);
+		const allowedAttributes = new Set(["href"]);
 
 		template.content.querySelectorAll("*").forEach((el) => {
 			if (!allowedTags.has(el.tagName)) {


### PR DESCRIPTION
### Features
- Added support for rendering HN story text (`story.text`) in the sidebar
- Clicking an HN story title in the sidebar now opens the Hacker News discussion instead of reloading the original article
- Added OP markers for comments made by the story author
- Comment collapse/expand state now persists between sessions
- New comments since the last visit are highlighted
- Added support for restoring sidebar position after moving the HN button
- Added migration support for existing HNewhere settings when storage keys changed

### Improvements
- Improved sidebar scroll behavior by making `#comments` a constrained flex scroll container
- Added `overscroll-behavior: contain` to prevent scroll chaining outside the sidebar
- Prevented wheel and touch events from propagating through the sidebar host to avoid interfering with pages that use JavaScript scroll handling
- Improved URL matching by normalizing tracking parameters before checking for HN discussions
- Added caching for HN lookups and comment data to reduce unnecessary requests
- Improved sidebar rendering stability with generation checks to prevent stale async renders

**Community contributions:**
- Add flex sizing and overscroll-behavior:contain to #comments so it constrains the scroll container which stops native scroll chain (Thanks @bennetthanke!)
- Stop wheel and touch propagation at sidebar host so sites with JS scroll hijacking don't scroll the page behind the sidebar (Thanks @bennetthanke!)