### PR TITLE
V1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The version in `HNewhere.user.js`'s `@version` header is what userscript managers
 use to detect updates, so every release bumps it.
 
+## [1.5.6] — 2026-07-31
+
+### Fixed
+
+- **[#35](https://github.com/twalichiewicz/HNewhere/issues/35)** — the discussion
+  lookup ran once, when the script loaded. On a site that navigates without
+  reloading — GitHub, and anything else built on Turbo or a client-side router —
+  whichever answer it computed first was the one it kept. Landing on a subpage
+  and moving to a page that had been posted left the button grey until a manual
+  reload; starting on the posted page and moving away left it orange on a page
+  that was never submitted. Navigation is now noticed and the page asked about
+  again, arriving at whatever a fresh load of that URL would have shown.
+
+  Three signals feed one debounced check, because no single one is reliable
+  everywhere: patching `history` is instant but only reaches the page in some
+  userscript managers, and is discarded without an error in others; `popstate`
+  always arrives but only covers back and forward; a poll catches the rest. A
+  fragment, an added tracking parameter, and a burst of pushes that ends where it
+  started are all still the same page, and leave the sidebar alone.
+- **[#37](https://github.com/twalichiewicz/HNewhere/issues/37)** — a comment's
+  text had no line length of its own, and ran to whatever width the panel had
+  been dragged to. It now takes a 1215px measure. The composer keeps the narrower
+  720px it already had, which is sized to an input rather than to reading.
+
+  The cap is on the text and nothing else. `.children` sits beside a comment's
+  text rather than around it, so a reply is not bounded by the comment it
+  answers: it starts further right and gets the full measure again. A cap on the
+  comment, the list, or the scrolling wrapper would instead compound with the
+  indent into a column that narrows at every level, which is the thing the indent
+  spends horizontal space to avoid.
+- A story's opening paragraph ran into the one below it, with no break between
+  them. Hacker News does not wrap the first paragraph of a story's text — it
+  emits it as bare text and wraps only the ones after it — so a rule zeroing the
+  top margin of `p:first-child` was never matching the first paragraph at all. It
+  matched the second, and closed the gap the reader needed. The comment renderer
+  takes the same markup and never had the rule.
+
 ## [1.5.5] — 2026-07-31
 
 ### Added
@@ -160,6 +197,8 @@ Releases before 1.4.7 are recorded in the
 commit history. Entries for 1.4.7 through 1.5.3 are summarized from their release
 commits rather than written at the time.
 
+[1.5.6]: https://github.com/twalichiewicz/HNewhere/compare/v1.5.5...v1.5.6
+[1.5.5]: https://github.com/twalichiewicz/HNewhere/compare/v1.5.4...v1.5.5
 [1.5.4]: https://github.com/twalichiewicz/HNewhere/compare/v1.5.3...v1.5.4
 [1.5.3]: https://github.com/twalichiewicz/HNewhere/compare/v1.5.2...v1.5.3
 [1.5.2]: https://github.com/twalichiewicz/HNewhere/compare/v1.5.1...v1.5.2

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HNewhere
 // @namespace    https://github.com/twalichiewicz/HNewhere
-// @version      1.5.5
+// @version      1.5.6
 // @license      MIT
 // @updateURL    https://raw.githubusercontent.com/twalichiewicz/HNewhere/main/HNewhere.user.js
 // @downloadURL  https://raw.githubusercontent.com/twalichiewicz/HNewhere/main/HNewhere.user.js
@@ -248,6 +248,7 @@
 	let sidebar = null;
 	let sidebarUI = null;
 	let opening = false;
+	let openingRun = null;
 	let sidebarGeneration = 0;
 	let renderedComments = [];
 	let annotationController = null;
@@ -4667,6 +4668,9 @@ Highlights the passages commenters quote, so you can jump between the article an
     font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     font-size:13px;
     overflow:visible;
+    /* Reading width for a single block of prose. Never applied to a container: a
+       cap on any ancestor of .children narrows every reply nested under it. */
+    --measure:1215px;
 }
 
 ${THEME_CSS}
@@ -4918,6 +4922,7 @@ ${CHROME_CSS}
     line-height:132%;
     font-weight:normal;
     cursor:text;
+    max-width:var(--measure);
 }
 
 .text p {
@@ -5244,10 +5249,8 @@ blockquote.comment-quote-redundant {
     cursor:text;
 }
 
-.story-text p:first-child {
-    margin-top:0;
-}
-
+/* No p:first-child rule to match: HN never wraps a story's opening paragraph, so
+   the first <p> is the second paragraph and zeroing it closed a real gap. */
 .story-text p:last-child {
     margin-bottom:0;
 }
@@ -6698,11 +6701,24 @@ ${settingsPanelHTML()}
 		}
 	}
 
-	async function openSidebar(stories, options = {}) {
-		if (opening) return;
+	// Still one open at a time, but the guard hands the in-flight run back rather
+	// than only refusing, so a navigation can wait for it to unwind.
+	function openSidebar(stories, options = {}) {
+		if (opening) {
+			return openingRun ?? Promise.resolve();
+		}
 
 		opening = true;
 
+		openingRun = runOpenSidebar(stories, options).finally(() => {
+			opening = false;
+			openingRun = null;
+		});
+
+		return openingRun;
+	}
+
+	async function runOpenSidebar(stories, options = {}) {
 		try {
 			const generation = ++sidebarGeneration;
 
@@ -6763,7 +6779,6 @@ ${settingsPanelHTML()}
 		} finally {
 			clearSidebarStage(sidebarUI);
 			stopButtonSpinner(document.getElementById("hn-restore-button"));
-			opening = false;
 		}
 	}
 
@@ -9165,13 +9180,13 @@ ${settingsPanelHTML()}
 		setTimeout(callback, 0);
 	}
 
-	// Ticking the blocklist toggle removes the sidebar the settings panel lives in,
-	// so callers must finish persisting before calling this and must not read
-	// sidebar or sidebarUI afterwards.
-	function teardownForBlockedSite() {
+	// Every surface this script puts on a page. Annotations go first: they unwrap
+	// quote links inside the sidebar's shadow root, so it has to still exist.
+	function teardownSurfaces() {
 		clearArticleAnnotations();
 
 		for (const id of [
+			BUTTON_PENDING_ID,
 			"hn-restore-button",
 			"hn-collapse-button",
 			"hn-submit-button",
@@ -9195,6 +9210,13 @@ ${settingsPanelHTML()}
 			sidebar = null;
 			sidebarUI = null;
 		}
+	}
+
+	// Ticking the blocklist toggle removes the sidebar the settings panel lives in,
+	// so callers must finish persisting before calling this and must not read
+	// sidebar or sidebarUI afterwards.
+	function teardownForBlockedSite() {
+		teardownSurfaces();
 	}
 
 	// Shared by both headers. Persists before tearing down, because the teardown
@@ -9263,6 +9285,94 @@ ${settingsPanelHTML()}
 	}
 
 	// -------------------------
+	// Soft navigation
+	// -------------------------
+
+	// The generation bump tells a render in flight to stop at its next checkpoint;
+	// awaiting openingRun is how we learn that it has.
+	async function teardownForNavigation() {
+		sidebarGeneration++;
+
+		if (openingRun) {
+			await openingRun.catch(() => {});
+		}
+
+		teardownSurfaces();
+
+		renderedComments = [];
+		activeCommentFilter = null;
+	}
+
+	// Routers push more than once for one navigation, and the new article is
+	// usually not in the DOM yet when they do, so the pass waits for the burst.
+	const SOFT_NAV_SETTLE_MS = 250;
+	const SOFT_NAV_POLL_MS = 400;
+
+	// Three feeds because none is sufficient alone: patching history is instant but
+	// only lands where the manager's sandbox shares the page's History object,
+	// popstate covers only back and forward, and the poll catches the rest.
+	function watchSoftNavigation() {
+		let currentHref = location.href;
+		let currentURL = normalizeURL(currentHref);
+		let timer = null;
+		let queue = Promise.resolve();
+
+		const check = () => {
+			if (location.href === currentHref) {
+				return;
+			}
+
+			currentHref = location.href;
+
+			// Normalized, so a fragment or a tracking parameter findHN already
+			// discards is not treated as a new page.
+			const nextURL = normalizeURL(currentHref);
+
+			if (nextURL === currentURL) {
+				return;
+			}
+
+			currentURL = nextURL;
+
+			clearTimeout(timer);
+
+			timer = setTimeout(() => {
+				// Chained, so two navigations cannot have one's teardown run against
+				// the other's half-built surfaces.
+				queue = queue
+					.then(async () => {
+						await teardownForNavigation();
+						await runPagePass();
+					})
+					.catch(console.error);
+			}, SOFT_NAV_SETTLE_MS);
+		};
+
+		for (const method of ["pushState", "replaceState"]) {
+			const original = history[method];
+
+			if (typeof original !== "function") {
+				continue;
+			}
+
+			try {
+				history[method] = function (...args) {
+					const result = original.apply(this, args);
+
+					check();
+
+					return result;
+				};
+			} catch {
+				// Frozen or isolated by the manager. Polling still catches it.
+			}
+		}
+
+		window.addEventListener("popstate", check);
+		setInterval(check, SOFT_NAV_POLL_MS);
+	}
+
+	// -------------------------
 	// Initialization
 	// -------------------------
 
@@ -9302,6 +9412,17 @@ ${settingsPanelHTML()}
 			return;
 		}
 
+		// Never gated on what the pass decides: a page the script declines to touch
+		// is exactly the one a reader navigates away from.
+		watchSoftNavigation();
+
+		await runPagePass();
+	}
+
+	// Split from init so a soft navigation can ask again. What stays above it --
+	// the storage migration, the HN bridge -- belongs to the document rather than
+	// to the page it is currently showing.
+	async function runPagePass() {
 		// After the HN branch, which has to keep working because the bridge popups run
 		// there, and before anything else: no lookup, no button, no stored state on a
 		// page that could never be a submission in the first place.


### PR DESCRIPTION
## v1.5.6

### Navigation (#35)
- The discussion lookup ran once, at load. On sites that navigate without reloading the first answer stuck until a manual refresh: a page that had been posted stayed grey, a page that never was stayed orange.
- Navigation is now detected and the page re-evaluated, landing wherever a fresh load of that URL would have. Three signals feed one debounced check: patched `history` (instant, but silently dropped by some managers' sandboxes), `popstate` (back/forward only), and a poll (catches the rest).
- Fragments, tracking parameters, and push bursts that end where they started are all still the same page, and leave the sidebar alone.
- `init` splits into one-time setup and a repeatable per-URL pass. `openSidebar` hands back its in-flight run, so a navigation can cancel a render and wait for it to unwind rather than replacing surfaces mid-write.

### Comment width (#37)
- A comment's text had no line length of its own and ran to whatever width the panel had been dragged to. Now capped at 1215px.
- The cap is on the text and nothing else. `.children` sits beside a comment's text rather than around it, so a reply starts further right and gets the full measure again.
- The composer keeps its own 720px, sized to an input rather than to reading.

### Story text
- A story's opening paragraph ran straight into the one below it. HN never wraps the first paragraph, instead emitting bare text and wrapping only what follows, so a rule zeroing the top margin of `p:first-child` was never matching the first paragraph. It matched the second, and closed a gap that belonged there. The comment renderer takes the same markup and never had the rule.