### PR TITLE
Point the repository's own links at its new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 A userscript that tells you what everyone's talking about.  
 ```
 
-<a href="https://trendshift.io/repositories/95983?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-95983" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/95983/daily?language=JavaScript" alt="twalichiewicz%2FHNewhere | Trendshift" width="250" height="55"/></a>
+<a href="https://trendshift.io/repositories/95983?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-95983" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/95983/daily?language=JavaScript" alt="twalichiewicz%2FBackchannel | Trendshift" width="250" height="55"/></a>
                                                
-<img width="1161" height="753" alt="A screenshot of Safari on macOS opened to https://john.fun/elevators, with the HNewhere side bar open viewing the comments. The settings dropdown in the sidebar is also open, showing which settings the user currently has enabled." src="https://github.com/user-attachments/assets/8f56269d-a707-4107-9e17-8d1c36e37daa" />
+<img width="1161" height="753" alt="A screenshot of Safari on macOS opened to https://john.fun/elevators, with the Backchannel side bar open viewing the comments. The settings dropdown in the sidebar is also open, showing which settings the user currently has enabled." src="https://github.com/user-attachments/assets/8f56269d-a707-4107-9e17-8d1c36e37daa" />
 
 ## What it does
 
@@ -39,9 +39,10 @@ Full detail, including a host-by-host table, in [SECURITY.md](SECURITY.md).
 ## Where did HNewhere go?
 
 Nothing went anywhere. **HNewhere is now Backchannel**. Same project, same
-repository, same install URL, same settings. It was renamed in v1.6.0 when it
+history, same install URL, same settings. It was renamed in v1.6.0 when it
 stopped being about one site: it now reads Hacker News and/or Reddit, and each
-source is a checkbox you control.
+source is a checkbox you control. The repository has since been renamed to
+match, and links to the old one redirect.
 
 If you already have it installed it updates itself and renames in place. Your hidden sites, your reading queue, your collapsed threads and your
 preferences all carry over untouched.
@@ -53,7 +54,7 @@ preferences all carry over untouched.
    - [Violentmonkey](https://violentmonkey.github.io/)
    - [Userscripts (Safari)](https://apps.apple.com/us/app/userscripts/id1463298887)
 
-2. [Install Backchannel](https://raw.githubusercontent.com/twalichiewicz/HNewhere/refs/heads/main/HNewhere.user.js)
+2. [Install Backchannel](https://raw.githubusercontent.com/twalichiewicz/Backchannel/refs/heads/main/HNewhere.user.js)
    - *Upgrading from HNewhere?* Let it auto-update and it renames itself. If you
      install from this link instead, delete the old **HNewhere** entry afterwards —
      managers match a manual install by name, so the rename arrives as a second

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ Your installed version is shown at the bottom of the settings panel.
 ## Reporting a vulnerability
 
 Please report privately rather than opening a public issue, using
-[GitHub's private vulnerability reporting](https://github.com/twalichiewicz/HNewhere/security/advisories/new)
+[GitHub's private vulnerability reporting](https://github.com/twalichiewicz/Backchannel/security/advisories/new)
 on this repository.
 
 Include what you need to reproduce it: the page or page type, your browser and


### PR DESCRIPTION
The repo is `twalichiewicz/Backchannel` now. GitHub redirects the old name, so nothing was broken. The README and security policy were still sending readers to a URL that only works by redirect, and one README sentence had quietly become untrue.

## Changes

| File | Was | Now |
| --- | --- | --- |
| `README.md` | Trendshift badge alt `twalichiewicz%2FHNewhere` | `twalichiewicz%2FBackchannel` |
| `README.md` | Screenshot alt "the HNewhere side bar" | "the Backchannel side bar" |
| `README.md` | "Same project, same **repository**, same install URL" | "same **history**" + a line saying the repo was renamed and old links redirect |
| `README.md` | Install link on the `/HNewhere/` raw path | `/Backchannel/` raw path |
| `SECURITY.md` | Advisory URL on `/HNewhere/` | `/Backchannel/` |

## Left alone deliberately

- **`HNewhere.user.js` keeps its filename.** Every installed copy fetches updates from that exact path, and raw file paths do not redirect the way repository names do. Renaming the file would silently strand existing installs.
- **The "Where did HNewhere go?" section still says HNewhere.** That is the point of it.
- **`.gitignore` and the contributing note** mention `HNewhere.user.js` as a filename, which is still correct.

## Verified

- `raw.githubusercontent.com/twalichiewicz/Backchannel/refs/heads/main/HNewhere.user.js` → `200`, byte-identical to the old path.
- The old `/HNewhere/` raw path still `200`s, so installed copies keep updating.
- The new advisory URL redirects to the login gate for the Backchannel repo.

## Not in this PR

The userscript header still carries the old name in `@namespace`, `@updateURL`, `@downloadURL`, `@homepageURL` and `@supportURL`. Those work by redirect today. Changing them only reaches users through a version bump, so it belongs to a release rather than a docs commit.