### PR TITLE
v1.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,15 @@ use to detect updates, so every release bumps it.
   editing a line, and the highlight moves to the words you left in it.
 
 - **Enhanced PDF support**, off by default, under Enable annotations. Turned on,
-  it covers the browser's PDF viewer with
-  [pdf.js](https://mozilla.github.io/pdf.js/), which is what makes highlighting
-  work in Chrome and Safari rather than only in Firefox. It is a choice rather
-  than the default because it downloads 1.74 MiB of pdf.js from
-  `cdn.jsdelivr.net` — the one part of the script that is not self-contained.
-  Safari's own PDF toolbar still floats above the reader and cannot be removed.
+  it covers Chrome's and Safari's PDF viewer with
+  [pdf.js](https://mozilla.github.io/pdf.js/), which is what lets a quoted
+  passage be highlighted on the PDF itself. It is a choice rather than the
+  default because it downloads 1.74 MiB of pdf.js from `cdn.jsdelivr.net` — the
+  one part of the script that is not self-contained. Safari's own PDF toolbar
+  still floats above the reader and cannot be removed. **Firefox is not covered
+  at all**: it reserves its built-in PDF viewer, no extension is allowed to run
+  there, and a PDF opened in Firefox gets no button, no sidebar and no
+  highlights — the setting has no effect.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The version in `HNewhere.user.js`'s `@version` header is what userscript managers
 use to detect updates, so every release bumps it.
 
+## [1.6.8] — 2026-08-12
+
+### Added
+
+- **A notepad of your own, on any page or PDF.** Select a passage and write what
+  you think of it, or open the notepad and write without selecting anything. A
+  note keeps the passage it was written about, so it lights up in the article the
+  way a commenter's quote does, and clicking it filters to the note. It sits in
+  its own section above the sort, and it is a setting rather than a source —
+  nobody else is in it, so it does not belong in a list of places to fetch from.
+  It is on to begin with, and unticking Enable notepad takes the section away.
+
+- Notes are yours to take away. **Export** next to the setting writes every note
+  across every document to a JSON file: the text, the quoted passage, and enough
+  context to find that passage again. Notes live in your userscript manager's
+  storage, which means they do not follow you to another browser and a manager
+  reset takes them with it — the export is the answer to both.
+
+- A note is edited as text rather than through a form. The quoted passage is a
+  `>` line at the top, so changing your mind about which words you meant is
+  editing a line, and the highlight moves to the words you left in it.
+
+- **Enhanced PDF support**, off by default, under Enable annotations. Turned on,
+  it covers the browser's PDF viewer with
+  [pdf.js](https://mozilla.github.io/pdf.js/), which is what makes highlighting
+  work in Chrome and Safari rather than only in Firefox. It is a choice rather
+  than the default because it downloads 1.74 MiB of pdf.js from
+  `cdn.jsdelivr.net` — the one part of the script that is not self-contained.
+  Safari's own PDF toolbar still floats above the reader and cannot be removed.
+
+### Changed
+
+- A PDF is named by its title. The panel used to head the discussion with the
+  host, so every paper on a preprint server read as the same thing.
+
+- Lemmy comments render their Markdown. Lemmy's API hands over Markdown rather
+  than HTML and it was being escaped and shown as written, so a link arrived as
+  `[text](url)`. Links, quotes, lists, emphasis and code now render; images
+  become links rather than loading anything into the panel. Measured across 1,899
+  comments from lemmy.world, quotes were the commonest thing in them, ahead of
+  emphasis and links. (#96)
+
+- Ticking Enable annotations, Enhanced PDF support or Enable notepad folds that
+  setting's explanation away, the way a source's caveat already does — the tick
+  is the acknowledgement.
+
+- Next in queue sits at the bottom of the sidebar when the discussion is short,
+  instead of following the last comment up the panel. A long thread is unchanged.
+
+### Fixed
+
+- One quoted passage that overlapped another stopped every highlight on the page
+  from being drawn, rather than just its own.
+
+- A quoted passage that runs across a line break inside a PDF anchors. The text
+  layer welds those lines together, so the words the commenter quoted and the
+  words in the document were not the same string.
+
+- Turning the notepad on or off applies immediately. It needed a page reload
+  before, because the setting was saved without anything being told to re-draw.
+
+- Notes line up with the comments beside them. A note sat eight pixels right of
+  every discussion comment, because the rule that clears that indent only ever
+  matched comments in the discussion list.
+
+- Collapsing or expanding a note resizes the notepad around it. The section keeps
+  an explicit height so it can animate, and that height was measured once and
+  never revisited, so an expanded note was cut off partway down.
+
+- The explanations under the settings checkboxes animate again. The rule that
+  gives them a height to collapse from had lost its opening `/*`, and the
+  malformed comment swallowed the height along with it.
+
+- PubPeer was measured for this release and is not viable as a source: its API
+  returns a comment count, the commenters' names and a link, and no comment text.
+  (#87)
+
 ## [1.6.7] — 2026-08-10
 
 ### Added

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -3838,15 +3838,65 @@ button {
 		return quote ? `> ${quote}\n\n${written}` : written;
 	}
 
-	function editedNote(note, parsed) {
-		const changed = parsed.exact !== String(note.exact || "").trim();
+	function anchorNoteQuote(exact) {
+		const wanted = normalizeSearchText(exact || "").text;
+
+		if (!wanted) {
+			return null;
+		}
+
+		const index = detectDocumentSource().buildIndex();
+
+		if (!index?.normalizedText) {
+			return null;
+		}
+
+		const found = findNormalizedOccurrences(
+			index.normalizedText,
+			wanted,
+			index.welded,
+		);
+
+		if (found.length !== 1) {
+			return null;
+		}
+
+		const at = found[0];
+		const ends = at + wanted.length;
+		const raw = index.normalizedMap?.[at];
+		const on =
+			index.pageStarts && raw != null
+				? findPageByOffset(index.pageStarts, raw)
+				: null;
+
+		return {
+			prefix: index.normalizedText.slice(Math.max(0, at - NOTE_CONTEXT_CHARS), at),
+			suffix: index.normalizedText.slice(ends, ends + NOTE_CONTEXT_CHARS),
+			page: on ? on.pageIndex + 1 : null,
+		};
+	}
+
+	function reanchoredNote(note, parsed) {
+		const anchor = parsed.exact ? anchorNoteQuote(parsed.exact) : null;
 
 		return {
 			...note,
 			text: parsed.text,
 			exact: parsed.exact,
+			prefix: anchor?.prefix || "",
+			suffix: anchor?.suffix || "",
+			page: anchor?.page ?? null,
+		};
+	}
+
+	function editedNote(note, parsed) {
+		const changed = parsed.exact !== String(note.exact || "").trim();
+
+		return {
+			...(changed ? reanchoredNote(note, parsed) : note),
+			text: parsed.text,
+			exact: parsed.exact,
 			edited: Date.now(),
-			...(changed ? { prefix: "", suffix: "", page: parsed.exact ? note.page : null } : {}),
 		};
 	}
 
@@ -3864,10 +3914,11 @@ button {
 		};
 	}
 
-	function inlineNoteEditor(note, { onSave, onClose }) {
+	function inlineNoteEditor(note, { onSave, onClose, canAnchor }) {
 		const editor = document.createElement("div");
 		const field = document.createElement("textarea");
 		const row = document.createElement("div");
+		const why = document.createElement("span");
 		const save = document.createElement("button");
 		const cancel = document.createElement("button");
 
@@ -3877,6 +3928,7 @@ button {
 		field.setAttribute("aria-label", "Edit your note");
 
 		row.className = "note-editor-row";
+		why.className = "note-editor-why";
 		cancel.type = "button";
 		cancel.className = "note-editor-cancel";
 		cancel.textContent = "cancel";
@@ -3884,12 +3936,28 @@ button {
 		save.className = "note-editor-save";
 		save.textContent = "save";
 
+		let warnedFor = null;
+
 		const commit = () => {
 			const parsed = noteFromText(field.value);
 
-			if (parsed.text || parsed.exact) {
-				onSave(parsed);
+			if (!parsed.text && !parsed.exact) {
+				return;
 			}
+
+			if (
+				parsed.exact &&
+				canAnchor &&
+				warnedFor !== parsed.exact &&
+				!canAnchor(parsed.exact)
+			) {
+				warnedFor = parsed.exact;
+				why.textContent =
+					"That passage is not in this document. Save again to keep it without a highlight.";
+				return;
+			}
+
+			onSave(parsed);
 		};
 
 		cancel.onclick = onClose;
@@ -3904,7 +3972,7 @@ button {
 			}
 		};
 
-		row.append(cancel, save);
+		row.append(why, cancel, save);
 		editor.append(field, row);
 
 		return { editor, field };
@@ -3947,6 +4015,8 @@ button {
 		}
 
 		const held = inlineNoteEditor(note, {
+			canAnchor: (exact) => Boolean(anchorNoteQuote(exact)),
+
 			onSave: (parsed) => {
 				updateNote(note.id, parsed).catch(console.error);
 			},
@@ -3972,6 +4042,8 @@ button {
 		}
 
 		const held = inlineNoteEditor(null, {
+			canAnchor: (exact) => Boolean(anchorNoteQuote(exact)),
+
 			onSave: (parsed) => {
 				writeNote(parsed).catch(console.error);
 			},
@@ -3996,19 +4068,17 @@ button {
 
 		await saveNotes([
 			...notes,
-			{
-				id:
-					"n" +
-					Date.now().toString(36) +
-					Math.floor(Math.random() * 1e6).toString(36),
-				created: Date.now(),
-				text: parsed.text,
-				exact: parsed.exact,
-				prefix: "",
-				suffix: "",
-				page: null,
-				url: location.href,
-			},
+			reanchoredNote(
+				{
+					id:
+						"n" +
+						Date.now().toString(36) +
+						Math.floor(Math.random() * 1e6).toString(36),
+					created: Date.now(),
+					url: location.href,
+				},
+				parsed,
+			),
 		]);
 		await reopenForNotes();
 	}
@@ -11608,8 +11678,15 @@ ${SUBMIT_FORM_CSS}
 .note-editor-row {
 	display:flex;
 	gap:8px;
+	align-items:baseline;
 	justify-content:flex-end;
 	margin-top:5px;
+}
+
+.note-editor-why {
+	margin-right:auto;
+	color:var(--meta);
+	font-size:11px;
 }
 
 .note-editor-row button {
@@ -17336,9 +17413,11 @@ title="Show only this discussion">
 	}
 	// #endregion hnewhere-test-export
 
+	// #region hnewhere-test-export
 	function buildArticleTextIndex() {
 		return documentSource().buildIndex();
 	}
+	// #endregion hnewhere-test-export
 
 	// #region hnewhere-test-export
 	function findNormalizedOccurrences(haystack, needle, welded = false) {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -11177,6 +11177,11 @@ ${[
 				return;
 			}
 
+			if (setting === "notepad") {
+				await reopenForNotes();
+				return;
+			}
+
 			if (["annotations", "annotationsWhenSidebarClosed"].includes(setting)) {
 				await onAnnotationChange?.();
 			}

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -3572,14 +3572,14 @@ ${
 			source: "notes",
 			key: sourceKey("notes", "notes"),
 			id: "notes",
-			title: "Your notes",
+			title: "Backchannel local notes",
 			author: "",
 			score: null,
 			commentCount: notes.length,
 			createdAt: Math.max(...notes.map((note) => note.created || 0)),
 			permalink: null,
 			articleURL,
-			label: "Your notes",
+			label: "Backchannel local notes",
 			collective: true,
 			bodyHTML: "",
 			rootKeys: notes.map((note) => sourceKey("notes", note.id)),
@@ -3648,6 +3648,37 @@ button {
 	}
 
 	// #region hnewhere-test-export
+	function rangeTextWelded(range) {
+		const walker = document.createTreeWalker(
+			range.commonAncestorContainer,
+			NodeFilter.SHOW_TEXT,
+		);
+		let text = "";
+		let node = walker.nextNode();
+
+		for (; node; node = walker.nextNode()) {
+			if (!range.intersectsNode(node)) {
+				continue;
+			}
+
+			const value = node.nodeValue || "";
+			const from = node === range.startContainer ? range.startOffset : 0;
+			const to = node === range.endContainer ? range.endOffset : value.length;
+
+			text += value.slice(from, to);
+		}
+
+		return text;
+	}
+
+	function selectedQuoteText(range, selection) {
+		const element = nearestElement(range.commonAncestorContainer);
+
+		return element?.closest(".textLayer")
+			? rangeTextWelded(range).replace(/\s+/g, " ").trim()
+			: String(selection).replace(/\s+/g, " ").trim();
+	}
+
 	function noteSelectionContext(range) {
 		const container =
 			nearestElement(range.commonAncestorContainer)?.closest(
@@ -3684,7 +3715,7 @@ button {
 			return null;
 		}
 
-		const exact = selection.toString().replace(/\s+/g, " ").trim();
+		const exact = selectedQuoteText(range, selection);
 
 		if (!exact) {
 			return null;
@@ -3906,7 +3937,7 @@ button {
 	registerSource({
 		id: "notes",
 		origins: [],
-		label: "Your notes",
+		label: "Backchannel local notes",
 		shortLabel: "Notes",
 		local: true,
 		defaultOn: true,
@@ -12969,7 +13000,7 @@ ${settingsPanelHTML()}
 		div.dataset.commentId = comment.key;
 		div.dataset.storyId = String(storyID);
 
-		if (isNewComment(comment, seenTime)) {
+		if (!getSource(comment.source)?.local && isNewComment(comment, seenTime)) {
 			div.classList.add("new-comment");
 		}
 
@@ -13021,7 +13052,7 @@ ${settingsPanelHTML()}
       <a class="focus-link" href="#">
       focus
       </a>
-		${comment.source === "notes" ? `|<a class="delete-note-link" href="#">delete</a>` : ""}
+		${comment.source === "notes" ? ` | <a class="delete-note-link" href="#">delete</a>` : ""}
 		${capabilities.vote ? itemActionLinksHTML(commentID, comment.source || "hn") : ""}
 
       <span class="toggle">
@@ -13327,7 +13358,10 @@ ${settingsPanelHTML()}
 		const liveNow = Math.floor(Date.now() / 1000);
 
 		stories.forEach((story, index) => {
-			if (isDiscussionLive(threads[index], liveNow)) {
+			if (
+				!getSource(story.source)?.local &&
+				isDiscussionLive(threads[index], liveNow)
+			) {
 				liveDiscussions.set(story.key, story.baseLabel || story.label || "");
 			}
 		});

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -11716,7 +11716,8 @@ ${SUBMIT_FORM_CSS}
 	overflow-wrap:anywhere;
 }
 
-.top-level-comments > .comment {
+.top-level-comments > .comment,
+.notepad-body > .comment {
 	margin-left:0;
 }
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -2822,6 +2822,26 @@ ${
 		option?.classList.toggle("settings-option-on", Boolean(input?.checked));
 	}
 
+	// #region hnewhere-test-export
+	const HINTED_SETTINGS = new Set(["annotations", "pdfReader", "notepad"]);
+
+	function syncOptionHint(input) {
+		const anchor =
+			input?.closest?.(".settings-option-row") ||
+			input?.closest?.(".settings-option");
+		const hint = anchor?.nextElementSibling;
+		const checked = Boolean(input?.checked);
+
+		anchor?.classList.toggle("is-checked", checked);
+
+		if (hint?.classList?.contains("settings-option-hint")) {
+			hint.classList.toggle("is-acknowledged", checked);
+		}
+
+		return checked;
+	}
+	// #endregion hnewhere-test-export
+
 	function enabledSources(settings) {
 		return enabledSourceIds(settings, registeredSourceIds()).map((id) =>
 			SOURCES.get(id),
@@ -10150,9 +10170,6 @@ header button svg {
 	color:var(--muted);
 	font-size:11px;
 	line-height:1.35;
-	   Stated in px for the same reason the hide menu is: rem here would be
-	   measured against the page's root font-size, and a site using the 62.5%
-	   reset would put this ceiling back below the caveats it has to clear. */
 	max-height:384px;
 	overflow:hidden;
 	transition:max-height .25s ease, margin-top .25s ease, opacity .2s ease;
@@ -11037,9 +11054,14 @@ ${[
 					: ".settings-pane-primary",
 			);
 
-			if (active) {
+			if (active?.scrollHeight) {
 				panes.style.height = `${active.scrollHeight}px`;
 			}
+		};
+
+		const settlePanesHeight = () => {
+			syncPanesHeight();
+			window.setTimeout(syncPanesHeight, 300);
 		};
 
 		if (panes && typeof ResizeObserver === "function") {
@@ -11121,6 +11143,10 @@ ${[
 			for (const [key, input] of Object.entries(settingsInputs)) {
 				if (input) {
 					input.checked = Boolean(settings[key]);
+
+					if (HINTED_SETTINGS.has(key)) {
+						syncOptionHint(input);
+					}
 				}
 			}
 
@@ -11322,6 +11348,7 @@ ${[
 			});
 
 			applySettingsPanelState(settings);
+			settlePanesHeight();
 
 			const setting = input.dataset.setting;
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -2105,11 +2105,149 @@
 			permalink: "https://lemmy.world/post/" + post.id,
 			articleURL: post.url || "",
 			label: "!" + (community.name || "") + (host ? "@" + host : ""),
-			bodyHTML: escapeHTML(post.body || ""),
+			bodyHTML: markdownToHTML(post.body || ""),
 			rootKeys: [],
 			rootTimes: [],
 			creatorId: post.creator_id,
 		};
+	}
+
+	function markdownAnchor(url, label) {
+		return /^https?:\/\//i.test(url) ? `<a href="${url}">${label}</a>` : label;
+	}
+
+	function markdownInline(escaped) {
+		const held = [];
+		const hold = (html) => `\u0000${held.push(html) - 1}\u0000`;
+
+		let out = escaped.replace(/`([^`\n]+)`/g, (m, body) =>
+			hold(`<code>${body}</code>`),
+		);
+
+		out = out.replace(/!\[([^\]\n]*)\]\(([^)\s]+)[^)]*\)/g, (m, alt, url) =>
+			hold(markdownAnchor(url, alt.trim() || "image")),
+		);
+
+		out = out.replace(/\[([^\]\n]*)\]\(([^)\s]+)[^)]*\)/g, (m, label, url) =>
+			hold(markdownAnchor(url, label.trim() || url)),
+		);
+
+		out = out.replace(
+			/(^|[\s(])(https?:\/\/[^\s<]*[^\s<.,;:!?)\]])/g,
+			(m, lead, url) => lead + hold(markdownAnchor(url, url)),
+		);
+
+		out = out
+			.replace(/\*\*(\S(?:[^*\n]*\S)?)\*\*/g, "<strong>$1</strong>")
+			.replace(/(^|[^*\w])\*(\S(?:[^*\n]*\S)?)\*(?!\*)/g, "$1<em>$2</em>")
+			.replace(/(^|[^_\w])_(\S(?:[^_\n]*\S)?)_(?!\w)/g, "$1<em>$2</em>");
+
+		return out.replace(/\u0000(\d+)\u0000/g, (m, index) => held[Number(index)]);
+	}
+
+	function markdownToHTML(text) {
+		const lines = String(text || "")
+			.replace(/\u0000/g, "")
+			.split("\n");
+		const out = [];
+		const paragraph = [];
+		let index = 0;
+
+		const flush = () => {
+			if (!paragraph.length) {
+				return;
+			}
+
+			out.push(
+				`<p>${markdownInline(escapeHTML(paragraph.join("\n"))).replace(/\n/g, "<br>")}</p>`,
+			);
+			paragraph.length = 0;
+		};
+
+		const items = (pattern, tag) => {
+			const collected = [];
+
+			while (index < lines.length && pattern.test(lines[index])) {
+				collected.push(lines[index].replace(pattern, ""));
+				index += 1;
+			}
+
+			out.push(
+				`<${tag}>` +
+					collected
+						.map((item) => `<li>${markdownInline(escapeHTML(item))}</li>`)
+						.join("") +
+					`</${tag}>`,
+			);
+		};
+
+		while (index < lines.length) {
+			const line = lines[index];
+
+			if (/^\s*```/.test(line)) {
+				flush();
+				index += 1;
+
+				const body = [];
+
+				while (index < lines.length && !/^\s*```/.test(lines[index])) {
+					body.push(lines[index]);
+					index += 1;
+				}
+
+				index += 1;
+				out.push(`<pre><code>${escapeHTML(body.join("\n"))}</code></pre>`);
+				continue;
+			}
+
+			if (/^\s*>\s?/.test(line)) {
+				flush();
+
+				const body = [];
+
+				while (index < lines.length && /^\s*>\s?/.test(lines[index])) {
+					body.push(lines[index].replace(/^\s*>\s?/, ""));
+					index += 1;
+				}
+
+				out.push(`<blockquote>${markdownToHTML(body.join("\n"))}</blockquote>`);
+				continue;
+			}
+
+			if (/^\s*[-*+]\s+\S/.test(line)) {
+				flush();
+				items(/^\s*[-*+]\s+/, "ul");
+				continue;
+			}
+
+			if (/^\s*\d+\.\s+\S/.test(line)) {
+				flush();
+				items(/^\s*\d+\.\s+/, "ol");
+				continue;
+			}
+
+			const heading = line.match(/^\s*#{1,6}\s+(.*)$/);
+
+			if (heading) {
+				flush();
+				out.push(`<p><strong>${markdownInline(escapeHTML(heading[1]))}</strong></p>`);
+				index += 1;
+				continue;
+			}
+
+			if (!line.trim()) {
+				flush();
+				index += 1;
+				continue;
+			}
+
+			paragraph.push(line);
+			index += 1;
+		}
+
+		flush();
+
+		return out.join("");
 	}
 
 	function lemmyComment(commentView, discussion) {
@@ -2126,7 +2264,7 @@
 			parentKey: parentId ? sourceKey("lemmy", parentId) : null,
 			author: lemmyHandle(commentView.creator),
 			authorName: lemmyDisplayName(commentView.creator),
-			bodyHTML: removed ? "" : escapeHTML(comment.content || ""),
+			bodyHTML: removed ? "" : markdownToHTML(comment.content || ""),
 			score: commentView.counts?.score ?? null,
 			createdAt: Math.floor(Date.parse(comment.published) / 1000) || 0,
 			isOP:

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -434,6 +434,7 @@
 
 	let sidebar = null;
 	let sidebarUI = null;
+	let renderedDiscussions = [];
 	let opening = false;
 	let openingRun = null;
 	let sidebarGeneration = 0;
@@ -3587,6 +3588,282 @@ ${
 		};
 	}
 	// #endregion hnewhere-test-export
+
+	const NOTE_COMPOSER_CSS = `
+:host { all: initial; }
+.box {
+	width: 320px;
+	max-width: 82vw;
+	padding: 10px;
+	border-radius: 10px;
+	background: var(--surface, #fff);
+	color: var(--surface-text, #111);
+	box-shadow: 0 8px 28px rgba(0,0,0,.28);
+	font: 13px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+blockquote {
+	margin: 0 0 8px;
+	padding: 0 0 0 8px;
+	border-left: 2px solid #237140;
+	color: #666;
+	font-style: italic;
+	max-height: 4.5em;
+	overflow: hidden;
+}
+textarea {
+	width: 100%;
+	min-height: 68px;
+	box-sizing: border-box;
+	padding: 6px 7px;
+	border: 1px solid rgba(0,0,0,.2);
+	border-radius: 6px;
+	font: inherit;
+	resize: vertical;
+}
+.row { display: flex; gap: 6px; justify-content: flex-end; margin-top: 8px; align-items: center; }
+.why { margin-right: auto; color: #a33; font-size: 12px; }
+button {
+	padding: 6px 11px;
+	border: 0;
+	border-radius: 6px;
+	font: inherit;
+	font-weight: 600;
+	cursor: pointer;
+}
+.save { background: #237140; color: #fff; }
+.cancel { background: rgba(0,0,0,.07); color: inherit; }
+@media (prefers-color-scheme: dark) {
+	.box { background: #23262b; color: #e8e8e8; }
+	blockquote { color: #aaa; }
+	textarea { background: #1a1c20; color: #e8e8e8; border-color: rgba(255,255,255,.18); }
+	.cancel { background: rgba(255,255,255,.12); }
+}
+`;
+
+	let noteComposer = null;
+
+	function closeNoteComposer() {
+		noteComposer?.host.remove();
+		noteComposer = null;
+	}
+
+	// #region hnewhere-test-export
+	function noteSelectionContext(range) {
+		const container =
+			nearestElement(range.commonAncestorContainer)?.closest(
+				".textLayer, article, main, body",
+			) || document.body;
+		const before = document.createRange();
+		const after = document.createRange();
+
+		before.setStart(container, 0);
+		before.setEnd(range.startContainer, range.startOffset);
+		after.setStart(range.endContainer, range.endOffset);
+		after.setEnd(container, container.childNodes.length);
+
+		return {
+			prefix: before.toString().replace(/\s+/g, " ").slice(-NOTE_CONTEXT_CHARS),
+			suffix: after.toString().replace(/\s+/g, " ").slice(0, NOTE_CONTEXT_CHARS),
+		};
+	}
+
+	function noteSelection() {
+		const selection = window.getSelection();
+
+		if (!selection || selection.isCollapsed || !selection.rangeCount) {
+			return null;
+		}
+
+		const range = selection.getRangeAt(0);
+		const element = nearestElement(range.commonAncestorContainer);
+
+		if (
+			!element ||
+			element.closest("[data-hnewhere-sidebar], [data-hnewhere-note-composer]")
+		) {
+			return null;
+		}
+
+		const exact = selection.toString().replace(/\s+/g, " ").trim();
+
+		if (!exact) {
+			return null;
+		}
+
+		const rect = [...range.getClientRects()].pop() || range.getBoundingClientRect();
+
+		return {
+			exact,
+			...noteSelectionContext(range),
+			anchorable: normalizeSearchText(exact).text.length >= QUOTE_MIN_CHARS,
+			page: Number(element.closest(".page")?.dataset.pageNumber) || null,
+			left: rect.right,
+			top: rect.bottom,
+		};
+	}
+	// #endregion hnewhere-test-export
+
+	async function openNoteComposer(chosen) {
+		closeNoteComposer();
+
+		const host = document.createElement("div");
+
+		host.setAttribute("data-hnewhere-note-composer", "1");
+		host.style.cssText = `
+			position:absolute;
+			left:${Math.max(8, Math.min(chosen.left + window.scrollX, window.scrollX + window.innerWidth - 340))}px;
+			top:${chosen.top + window.scrollY + 8}px;
+			z-index:2147483646;
+		`;
+
+		const shadow = host.attachShadow({ mode: "open" });
+
+		shadow.innerHTML = `
+<style>${NOTE_COMPOSER_CSS}</style>
+<div class="box">
+<blockquote></blockquote>
+<textarea placeholder="Your note" aria-label="Your note"></textarea>
+<div class="row">
+<span class="why"></span>
+<button type="button" class="cancel">Cancel</button>
+<button type="button" class="save">Save note</button>
+</div>
+</div>`;
+
+		shadow.querySelector("blockquote").textContent = chosen.exact;
+
+		if (!chosen.anchorable) {
+			shadow.querySelector(".why").textContent =
+				"Too short to highlight — it will be kept as a note on the page.";
+		}
+
+		const field = shadow.querySelector("textarea");
+
+		shadow.querySelector(".cancel").onclick = () => closeNoteComposer();
+		shadow.querySelector(".save").onclick = () => {
+			saveNoteFromComposer(chosen, field.value).catch(console.error);
+		};
+		field.onkeydown = (event) => {
+			if (event.key === "Escape") {
+				closeNoteComposer();
+			}
+
+			if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+				saveNoteFromComposer(chosen, field.value).catch(console.error);
+			}
+		};
+
+		document.documentElement.appendChild(host);
+		noteComposer = { host, shadow };
+		field.focus();
+	}
+
+	async function saveNoteFromComposer(chosen, text) {
+		const why = noteComposer?.shadow.querySelector(".why");
+
+		if (!String(text || "").trim()) {
+			if (why) {
+				why.textContent = "A note needs something written in it.";
+			}
+
+			return;
+		}
+
+		const notes = await loadNotes();
+
+		await saveNotes([
+			...notes,
+			{
+				id: "n" + Date.now().toString(36) + Math.floor(Math.random() * 1e6).toString(36),
+				created: Date.now(),
+				text: String(text).trim(),
+				exact: chosen.anchorable ? chosen.exact : "",
+				prefix: chosen.prefix,
+				suffix: chosen.suffix,
+				page: chosen.page,
+				url: location.href,
+			},
+		]);
+
+		closeNoteComposer();
+		window.getSelection()?.removeAllRanges();
+		await reopenForNotes();
+	}
+
+	async function deleteNote(id) {
+		const notes = await loadNotes();
+
+		await saveNotes(notes.filter((note) => note.id !== id));
+		await reopenForNotes();
+	}
+
+	async function reopenForNotes() {
+		if (!sidebarUI) {
+			return;
+		}
+
+		const found = (await getSource("notes")?.discover(pageAddress())) || [];
+		const others = renderedDiscussions.filter((story) => story.source !== "notes");
+		const next = [...others, ...found];
+
+		if (!next.length) {
+			return;
+		}
+
+		await renderDiscussions(next, sidebarUI);
+		await refreshArticleAnnotations();
+	}
+
+	function removeNoteAffordance() {
+		document.querySelector("[data-hnewhere-note-add]")?.remove();
+	}
+
+	function syncNoteAffordance() {
+		if (noteComposer) {
+			return;
+		}
+
+		removeNoteAffordance();
+
+		const chosen = noteSelection();
+
+		if (!chosen) {
+			return;
+		}
+
+		const wrapper = document.createElement("div");
+
+		wrapper.setAttribute("data-hnewhere-note-add", "1");
+		wrapper.style.cssText = `
+			position:absolute;
+			left:${chosen.left + window.scrollX}px;
+			top:${chosen.top + window.scrollY + 6}px;
+			z-index:2147483646;
+		`;
+		wrapper.appendChild(
+			pdfReaderButton("Add note", () => {
+				removeNoteAffordance();
+				openNoteComposer(chosen).catch(console.error);
+			}),
+		);
+
+		document.documentElement.appendChild(wrapper);
+	}
+
+	function watchNoteSelection(settings) {
+		if (!enabledSourceIds(settings, registeredSourceIds()).includes("notes")) {
+			return;
+		}
+
+		const later = () => window.setTimeout(syncNoteAffordance, 0);
+
+		document.addEventListener("pointerup", later);
+		document.addEventListener("keyup", (event) => {
+			if (event.key === "Shift" || String(event.key).startsWith("Arrow")) {
+				later();
+			}
+		});
+	}
 
 	function noteDocumentRefForPage() {
 		return noteDocumentRef(pdfViewerApp()?.pdfDocument?.fingerprints?.[0]);
@@ -12744,6 +13021,7 @@ ${settingsPanelHTML()}
       <a class="focus-link" href="#">
       focus
       </a>
+		${comment.source === "notes" ? `|<a class="delete-note-link" href="#">delete</a>` : ""}
 		${capabilities.vote ? itemActionLinksHTML(commentID, comment.source || "hn") : ""}
 
       <span class="toggle">
@@ -12829,6 +13107,15 @@ ${settingsPanelHTML()}
 		};
 
 		const replyButton = div.querySelector(".reply-link");
+		const deleteNoteButton = div.querySelector(".delete-note-link");
+
+		if (deleteNoteButton) {
+			deleteNoteButton.onclick = (event) => {
+				event.preventDefault();
+				deleteNote(comment.id).catch(console.error);
+			};
+		}
+
 		const focusButton = div.querySelector(".focus-link");
 		const replyComposer = div.querySelector(".reply-composer");
 
@@ -12987,6 +13274,7 @@ ${settingsPanelHTML()}
 	}
 
 	async function renderDiscussions(stories, ui) {
+		renderedDiscussions = stories;
 		clearArticleAnnotations();
 		clearCommentFilter({ animate: false });
 		setWordmarkLocation(ui, "Discussion");
@@ -15289,6 +15577,8 @@ title="Show only this discussion">
 		return variants.sort((a, b) => b.normalized.length - a.normalized.length);
 	}
 
+	const QUOTE_MIN_CHARS = 24;
+
 	function extractQuotedTextCandidates(commentHTML) {
 		const template = document.createElement("template");
 		template.innerHTML = commentHTML || "";
@@ -15305,7 +15595,7 @@ title="Show only this discussion">
 
 			const normalized = normalizeSearchText(value).text;
 
-			if (normalized.length < 24 || seen.has(normalized)) {
+			if (normalized.length < QUOTE_MIN_CHARS || seen.has(normalized)) {
 				return;
 			}
 
@@ -18363,6 +18653,7 @@ title="Show only this discussion">
 
 		await ensurePdfReader(settings);
 		await loadPdfTitle(pdfViewerApp());
+		watchNoteSelection(settings);
 
 		const votesReady = Promise.all([
 			loadRememberedVotes(),

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -44,8 +44,8 @@
 // @grant        GM.xmlHttpRequest
 // @grant        GM.getResourceText
 // @grant        unsafeWindow
-// @resource     pdfjsCore   https://cdn.jsdelivr.net/npm/pdfjs-dist@6.2.108/build/pdf.min.mjs
-// @resource     pdfjsWorker https://cdn.jsdelivr.net/npm/pdfjs-dist@6.2.108/build/pdf.worker.min.mjs
+// @resource     pdfjsCore   https://cdn.jsdelivr.net/npm/pdfjs-dist@6.2.108/legacy/build/pdf.min.mjs
+// @resource     pdfjsWorker https://cdn.jsdelivr.net/npm/pdfjs-dist@6.2.108/legacy/build/pdf.worker.min.mjs
 // @connect      hacker-news.firebaseio.com
 // @connect      hn.algolia.com
 // @connect      news.ycombinator.com
@@ -8164,6 +8164,15 @@ header {
 	display:none;
 }
 
+.hide-menu-rule {
+	margin:4px 2px;
+	border-top:1px solid var(--surface-border);
+}
+
+.hide-menu-rule[hidden] {
+	display:none;
+}
+
 .hide-menu button {
 	padding:5px 8px;
 	border:0;
@@ -9719,6 +9728,8 @@ ${
 	`<div id="hide-menu" class="hide-menu" role="menu" hidden>
 <button type="button" role="menuitem" data-hide-scope="page">Hide on this page only</button>
 <button type="button" role="menuitem" data-hide-scope="site">Hide on all ${escapeHTML(siteKey())} pages</button>
+<div class="hide-menu-rule" data-pdf-reader-only hidden></div>
+<button id="close-pdf-reader" type="button" role="menuitem" data-pdf-reader-only hidden>Close the PDF reader</button>
 </div>`
 }
 
@@ -9779,12 +9790,12 @@ Highlights the passages commenters quote, so you can jump between the article an
 </label>
 <label class="settings-option sub-option">
 <input id="setting-pdf-reader" data-setting="pdfReader" type="checkbox">
-<span>Read PDFs here, so passages can be highlighted</span>
+<span>Enhanced PDF support</span>
 </label>
 <div class="settings-option-hint">
-Chrome and Safari keep a PDF's text out of the page, so nothing can be
-highlighted in one. With this on, a PDF offers to open in a reader that can —
-and closing it puts your browser's viewer back.
+The default PDF reader will be replaced with
+<a href="https://mozilla.github.io/pdf.js/" target="_blank" rel="noreferrer noopener">pdf.js</a>,
+allowing highlighting and annotation directly onto the PDF.
 </div>
 </div>
 </div>
@@ -10125,6 +10136,10 @@ ${[
 				return;
 			}
 
+			for (const node of hideMenu.querySelectorAll("[data-pdf-reader-only]")) {
+				node.hidden = !ownPdfReader;
+			}
+
 			hideMenu.hidden = !open;
 			hideSiteButton.classList.toggle("is-open", open);
 			hideSiteButton.setAttribute("aria-expanded", open ? "true" : "false");
@@ -10151,6 +10166,18 @@ ${[
 					event.preventDefault();
 					event.stopPropagation();
 					hideCurrentSite(choice.dataset.hideScope).catch(console.error);
+				};
+			}
+
+			const closeReader = shadow.querySelector("#close-pdf-reader");
+
+			if (closeReader) {
+				closeReader.onclick = (event) => {
+					event.preventDefault();
+					event.stopPropagation();
+					setHideMenuOpen(false);
+					closePdfReader();
+					refreshArticleAnnotations().catch(console.error);
 				};
 			}
 
@@ -14461,13 +14488,19 @@ title="Show only this discussion">
 		return Boolean(sidebar && sidebar.style.display !== "none");
 	}
 
-	function shouldShowArticleAnnotations(settings) {
+	// #region hnewhere-test-export
+	function shouldShowArticleAnnotations(settings, sidebarVisible = isSidebarVisible()) {
 		if (!settings.annotations) {
 			return false;
 		}
 
-		return isSidebarVisible() || Boolean(settings.annotationsWhenSidebarClosed);
+		return (
+			sidebarVisible ||
+			Boolean(settings.annotationsWhenSidebarClosed) ||
+			Boolean(ownPdfReader)
+		);
 	}
+	// #endregion hnewhere-test-export
 
 	async function ensureVoteControlsLoaded() {
 		if (!isSidebarVisible() || !sidebarUI?.body) {
@@ -15337,6 +15370,10 @@ title="Show only this discussion">
 			);
 		},
 
+		backdropFor(range) {
+			return nearestElement(range?.commonAncestorContainer);
+		},
+
 		scrollIntoView(range) {
 			const rect = range.getBoundingClientRect();
 
@@ -15391,11 +15428,11 @@ title="Show only this discussion">
 	// -------------------------
 
 	const PDFJS_VERSION = "6.2.108";
-	const PDFJS_BASE = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/build/`;
+	const PDFJS_BASE = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/legacy/build/`;
 
 	const PDF_READER_CSS = `
 .hnewhere-pdf-viewer { --scale-factor: 1; --total-scale-factor: 1; --scale-round-x: 1px; --scale-round-y: 1px; }
-.hnewhere-pdf-viewer .page { position: relative; margin: 0 auto 12px; background: #fff; box-shadow: 0 1px 4px rgba(0,0,0,.3); }
+.hnewhere-pdf-viewer .page { position: relative; margin: 12px auto; background: #fff; box-shadow: 0 1px 4px rgba(0,0,0,.3); }
 .hnewhere-pdf-viewer .canvasWrapper { position: absolute; inset: 0; overflow: hidden; }
 .hnewhere-pdf-viewer .canvasWrapper canvas { display: block; }
 .hnewhere-pdf-viewer .textLayer {
@@ -15410,6 +15447,7 @@ title="Show only this discussion">
 .hnewhere-pdf-viewer .textLayer :is(span, br) {
 	color: transparent; position: absolute; white-space: pre; cursor: text;
 	transform-origin: 0% 0%;
+	-webkit-user-select: text; user-select: text;
 }
 .hnewhere-pdf-viewer .textLayer > :not(.markedContent),
 .hnewhere-pdf-viewer .textLayer .markedContent span:not(.markedContent) {
@@ -15421,6 +15459,12 @@ title="Show only this discussion">
 	transform: rotate(var(--rotate)) scaleX(var(--scale-x)) scale(var(--min-font-size-inv));
 }
 .hnewhere-pdf-viewer .textLayer .markedContent { display: contents; }
+.hnewhere-pdf-viewer .textLayer .endOfContent {
+	display: block; position: absolute; inset: 100% 0 0; z-index: 0;
+	cursor: default; transform: none; font-size: inherit;
+	-webkit-user-select: none; user-select: none;
+}
+.hnewhere-pdf-viewer .textLayer.selecting .endOfContent { top: 0; }
 `;
 
 	let pdfjsModule = null;
@@ -15447,6 +15491,65 @@ title="Show only this discussion">
 		return (await fetch(url, { cache: "force-cache" })).text();
 	}
 
+	function importModuleViaPage(url) {
+		const scope = typeof unsafeWindow !== "undefined" ? unsafeWindow : window;
+		const key = "__hnewherePdfjsModule";
+
+		return new Promise((resolve, reject) => {
+			const script = document.createElement("script");
+			const timer = setTimeout(
+				() => reject(new Error("timed out loading pdf.js in the page")),
+				20000,
+			);
+			const finish = (value, error) => {
+				clearTimeout(timer);
+				script.remove();
+
+				try {
+					delete scope[key];
+				} catch {
+					/* empty */
+				}
+
+				error ? reject(error) : resolve(value);
+			};
+
+			document.addEventListener(
+				key,
+				() => {
+					const module_ = scope[key];
+
+					finish(
+						module_,
+						module_ ? null : new Error("pdf.js loaded but exported nothing"),
+					);
+				},
+				{ once: true },
+			);
+
+			script.type = "module";
+			script.textContent =
+				`import * as m from ${JSON.stringify(url)};` +
+				`window[${JSON.stringify(key)}] = m;` +
+				`document.dispatchEvent(new CustomEvent(${JSON.stringify(key)}));`;
+			script.addEventListener("error", () =>
+				finish(null, new Error("a module script is not allowed on this page")),
+			);
+
+			(document.head || document.documentElement).appendChild(script);
+		});
+	}
+
+	async function importModuleText(text) {
+		const url = URL.createObjectURL(new Blob([text], { type: "text/javascript" }));
+
+		try {
+			return await import(url);
+		} catch {
+			return await importModuleViaPage(url);
+		}
+	}
+
 	async function loadPdfjs() {
 		if (pdfjsModule) {
 			return pdfjsModule;
@@ -15457,11 +15560,11 @@ title="Show only this discussion">
 			pdfjsResourceText("pdfjsWorker", PDFJS_BASE + "pdf.worker.min.mjs"),
 		]);
 
-		const asURL = (text) =>
-			URL.createObjectURL(new Blob([text], { type: "text/javascript" }));
-		const module_ = await import(asURL(core));
+		const module_ = await importModuleText(core);
 
-		module_.GlobalWorkerOptions.workerSrc = asURL(worker);
+		module_.GlobalWorkerOptions.workerSrc = URL.createObjectURL(
+			new Blob([worker], { type: "text/javascript" }),
+		);
 		pdfjsModule = module_;
 
 		return module_;
@@ -15519,10 +15622,18 @@ title="Show only this discussion">
 		return button;
 	}
 
+	function pdfReaderFitScale(host, base) {
+		const byWidth = (host.clientWidth - 32) / base.width;
+		const byHeight = (host.clientHeight - 24) / base.height;
+
+		return Math.max(0.2, Math.min(3, Math.min(byWidth, byHeight) || 1));
+	}
+
 	function buildPdfReaderChrome() {
 		const host = document.createElement("div");
 
 		host.setAttribute("data-hnewhere-pdf-reader", "1");
+		host.tabIndex = -1;
 		host.style.cssText = `
 			position:fixed;
 			inset:0;
@@ -15530,6 +15641,7 @@ title="Show only this discussion">
 			background:#3a3a3a;
 			overflow:auto;
 			overscroll-behavior:contain;
+			outline:none;
 		`;
 
 		const style = document.createElement("style");
@@ -15537,68 +15649,11 @@ title="Show only this discussion">
 
 		const viewer = document.createElement("div");
 		viewer.className = "hnewhere-pdf-viewer pdfViewer";
-		viewer.style.cssText = "position:relative;padding:12px 0;";
+		viewer.style.cssText = "position:relative;";
 
-		const bar = document.createElement("div");
-		bar.style.cssText = `
-			position:fixed;
-			right:16px;
-			bottom:16px;
-			z-index:1;
-			display:flex;
-			gap:8px;
-			align-items:center;
-		`;
-
-		const counter = document.createElement("span");
-		counter.setAttribute("data-hnewhere-pdf-counter", "1");
-		counter.style.cssText = `
-			padding:8px 12px;
-			border-radius:8px;
-			background:rgba(0,0,0,.55);
-			color:#fff;
-			font:600 13px/1 system-ui, -apple-system, sans-serif;
-			white-space:nowrap;
-		`;
-
-		bar.append(
-			counter,
-			pdfReaderButton("−", () => {
-				setPdfReaderScale((ownPdfReader?.scale || 1) / 1.25).catch(console.error);
-			}),
-			pdfReaderButton("+", () => {
-				setPdfReaderScale((ownPdfReader?.scale || 1) * 1.25).catch(console.error);
-			}),
-			pdfReaderButton("Close reader", () => {
-				closePdfReader();
-				refreshArticleAnnotations().catch(console.error);
-			}),
-		);
-
-		host.append(style, viewer, bar);
+		host.append(style, viewer);
 
 		return host;
-	}
-
-	function syncPdfReaderCounter() {
-		const reader = ownPdfReader;
-		const counter = reader?.host.querySelector("[data-hnewhere-pdf-counter]");
-
-		if (!counter) {
-			return;
-		}
-
-		const top = reader.host.getBoundingClientRect().top;
-		let current = 1;
-
-		for (const box of reader.pages) {
-			if (box.getBoundingClientRect().bottom > top + 8) {
-				current = Number(box.dataset.pageNumber);
-				break;
-			}
-		}
-
-		counter.textContent = `${current} / ${reader.pages.length}`;
 	}
 
 	async function drawPdfReaderVisiblePages() {
@@ -15653,49 +15708,88 @@ title="Show only this discussion">
 		reader.bus.dispatch("scalechanging", { scale: next, source: reader.app });
 
 		await drawPdfReaderVisiblePages();
-		syncPdfReaderCounter();
 	}
 
-	function removePdfReaderOffer() {
-		document.querySelector("[data-hnewhere-pdf-offer]")?.remove();
+	function reportPdfReaderFailure(error) {
+		document.querySelector("[data-hnewhere-pdf-failed]")?.remove();
+
+		const notice = document.createElement("div");
+
+		notice.setAttribute("data-hnewhere-pdf-failed", "1");
+		notice.style.cssText = `
+			position:fixed;
+			left:50%;
+			bottom:24px;
+			transform:translateX(-50%);
+			z-index:2147483643;
+			max-width:min(90vw,520px);
+			padding:10px 14px;
+			border-radius:8px;
+			background:rgba(0,0,0,.82);
+			color:#fff;
+			font:400 13px/1.45 system-ui, -apple-system, sans-serif;
+		`;
+		notice.textContent =
+			"Backchannel could not read this PDF here: " +
+			String(error?.message || error);
+
+		notice.appendChild(
+			pdfReaderButton("Dismiss", () => notice.remove()),
+		);
+
+		document.documentElement.appendChild(notice);
 	}
 
-	function syncPdfReaderOffer(settings) {
-		removePdfReaderOffer();
+	function canPaintOverDocumentViewer() {
+		const probe = document.createElement("div");
 
+		probe.setAttribute("data-hnewhere-paint-probe", "1");
+		probe.style.cssText =
+			"position:fixed;inset:0;z-index:2147483644;background:transparent;";
+		document.documentElement.appendChild(probe);
+
+		const at = document.elementFromPoint(
+			Math.floor(window.innerWidth / 2),
+			Math.floor(window.innerHeight / 2),
+		);
+
+		probe.remove();
+
+		return (
+			at === probe ||
+			at === null ||
+			at === document.documentElement ||
+			at === document.body
+		);
+	}
+
+	async function ensurePdfReader(settings) {
 		if (
+			ownPdfReader ||
 			!settings?.annotations ||
 			!settings.pdfReader ||
-			ownPdfReader ||
 			!looksLikePdfDocument() ||
 			document.querySelector(".pdfViewer .textLayer")
 		) {
 			return;
 		}
 
-		const offer = document.createElement("div");
+		if (!canPaintOverDocumentViewer()) {
+			reportPdfReaderFailure(
+				new Error(
+					"this browser draws its PDF viewer above the page, so a reader cannot be put in front of it",
+				),
+			);
+			return;
+		}
 
-		offer.setAttribute("data-hnewhere-pdf-offer", "1");
-		offer.style.cssText = `
-			position:fixed;
-			left:50%;
-			bottom:24px;
-			transform:translateX(-50%);
-			z-index:2147483643;
-		`;
-		offer.appendChild(
-			pdfReaderButton("Open this PDF where passages can be highlighted", () => {
-				removePdfReaderOffer();
-				openPdfReader()
-					.then(() => refreshArticleAnnotations())
-					.catch((e) => {
-						console.error("Backchannel could not open the PDF reader:", e);
-						closePdfReader();
-					});
-			}),
-		);
-
-		document.documentElement.appendChild(offer);
+		try {
+			await openPdfReader();
+		} catch (error) {
+			console.error("Backchannel could not open the PDF reader:", error);
+			closePdfReader();
+			reportPdfReaderFailure(error);
+		}
 	}
 
 	async function drawPdfReaderPage(number) {
@@ -15748,6 +15842,20 @@ title="Show only this discussion">
 			return;
 		}
 
+		const endOfContent = document.createElement("div");
+		endOfContent.className = "endOfContent";
+		layer.appendChild(endOfContent);
+
+		layer.addEventListener("pointerdown", () => {
+			layer.classList.add("selecting");
+
+			document.addEventListener(
+				"pointerup",
+				() => layer.classList.remove("selecting"),
+				{ once: true },
+			);
+		});
+
 		reader.bus.dispatch("textlayerrendered", {
 			pageNumber: number,
 			source: reader.app,
@@ -15779,6 +15887,67 @@ title="Show only this discussion">
 		}
 	}
 
+	const PDF_ZOOM_IN_KEYS = new Set(["=", "+"]);
+	const PDF_ZOOM_OUT_KEYS = new Set(["-", "_"]);
+
+	function installPdfReaderZoom() {
+		const reader = ownPdfReader;
+
+		if (!reader) {
+			return;
+		}
+
+		const onKeyDown = (event) => {
+			if (!ownPdfReader || !(event.metaKey || event.ctrlKey) || event.altKey) {
+				return;
+			}
+
+			const step = PDF_ZOOM_IN_KEYS.has(event.key)
+				? reader.scale * 1.2
+				: PDF_ZOOM_OUT_KEYS.has(event.key)
+					? reader.scale / 1.2
+					: event.key === "0"
+						? reader.fitScale
+						: null;
+
+			if (step === null) {
+				return;
+			}
+
+			event.preventDefault();
+			setPdfReaderScale(step).catch(console.error);
+		};
+
+		const onWheel = (event) => {
+			if (!ownPdfReader || !event.ctrlKey) {
+				return;
+			}
+
+			event.preventDefault();
+			setPdfReaderScale(reader.scale * (event.deltaY < 0 ? 1.05 : 0.95)).catch(
+				console.error,
+			);
+		};
+
+		const takeFocus = () => {
+			if (ownPdfReader === reader && !reader.host.contains(document.activeElement)) {
+				reader.host.focus({ preventScroll: true });
+			}
+		};
+
+		window.addEventListener("keydown", onKeyDown, { capture: true });
+		reader.host.addEventListener("wheel", onWheel, { passive: false });
+		reader.host.addEventListener("pointerdown", takeFocus);
+
+		takeFocus();
+
+		reader.stopZoom = () => {
+			window.removeEventListener("keydown", onKeyDown, { capture: true });
+			reader.host.removeEventListener("wheel", onWheel);
+			reader.host.removeEventListener("pointerdown", takeFocus);
+		};
+	}
+
 	async function openPdfReader() {
 		if (ownPdfReader) {
 			return ownPdfReader;
@@ -15794,10 +15963,7 @@ title="Show only this discussion">
 		document.documentElement.appendChild(host);
 
 		const base = (await pdfDocument.getPage(1)).getViewport({ scale: 1 });
-		const scale = Math.max(
-			0.2,
-			Math.min(3, (host.clientWidth - 32) / base.width || 1),
-		);
+		const scale = pdfReaderFitScale(host, base);
 		const sized = (await pdfDocument.getPage(1)).getViewport({ scale });
 		const pages = [];
 
@@ -15825,28 +15991,27 @@ title="Show only this discussion">
 			pages,
 			pdfjs,
 			scale,
+			fitScale: scale,
 			drawn: new Set(),
 			observer: null,
+			stopZoom: null,
 		};
 
 		observePdfReaderPages();
-		syncPdfReaderCounter();
-
-		host.addEventListener("scroll", syncPdfReaderCounter, { passive: true });
+		installPdfReaderZoom();
 		bus.dispatch("pagesloaded", { source: ownPdfReader.app });
 
 		return ownPdfReader;
 	}
 
 	function closePdfReader() {
-		const reader = ownPdfReader;
+		ownPdfReader?.stopZoom?.();
+		ownPdfReader?.observer?.disconnect();
 
-		if (!reader) {
-			return;
+		for (const host of document.querySelectorAll("[data-hnewhere-pdf-reader]")) {
+			host.remove();
 		}
 
-		reader.observer?.disconnect();
-		reader.host.remove();
 		ownPdfReader = null;
 		pdfTexts = null;
 		pdfTextsFor = null;
@@ -15920,6 +16085,23 @@ title="Show only this discussion">
 		}
 	}
 
+	async function pdfPageTextItems(page) {
+		const reader = page.streamTextContent().getReader();
+		const items = [];
+
+		for (;;) {
+			const chunk = await reader.read();
+
+			if (chunk.done) {
+				return items;
+			}
+
+			for (const item of chunk.value?.items || []) {
+				items.push(item);
+			}
+		}
+	}
+
 	function pdfDocumentTexts(app) {
 		if (pdfTextsFor === app.pdfDocument) {
 			return pdfTexts;
@@ -15937,9 +16119,9 @@ title="Show only this discussion">
 
 			for (let number = 1; number <= document_.numPages; number += 1) {
 				const page = await document_.getPage(number);
-				const content = await page.getTextContent();
+				const items = await pdfPageTextItems(page);
 
-				texts.push(content.items.map((item) => item.str).join(""));
+				texts.push(items.map((item) => item.str).join(""));
 			}
 
 			if (app.pdfDocument !== document_) {
@@ -16043,6 +16225,12 @@ title="Show only this discussion">
 			return host === document.body
 				? HTML_DOCUMENT_SOURCE.heightFor(host)
 				: host.scrollHeight;
+		},
+
+		backdropFor(range) {
+			const element = nearestElement(range?.commonAncestorContainer);
+
+			return element?.closest(".page") || ownPdfReader?.pages[0] || element;
 		},
 
 		scrollIntoView(range) {
@@ -17443,8 +17631,8 @@ title="Show only this discussion">
 			rectsByGroup.clear();
 
 			const backdrop =
-				nearestElement(groups[0]?.range?.commonAncestorContainer) ||
-				nearestElement(heatRegions[0]?.range?.commonAncestorContainer) ||
+				source.backdropFor(groups[0]?.range) ||
+				source.backdropFor(heatRegions[0]?.range) ||
 				document.body;
 			const dark = isDarkBackdrop(backdrop);
 
@@ -17686,7 +17874,6 @@ title="Show only this discussion">
 
 	async function refreshArticleAnnotations() {
 		clearArticleAnnotations();
-		syncPdfReaderOffer(await loadSettings());
 
 		if (!sidebar || !renderedComments.length) {
 			return;
@@ -17904,6 +18091,8 @@ title="Show only this discussion">
 		sweepBridgePayloads().catch(console.error);
 
 		markQueueArrival().catch(console.error);
+
+		await ensurePdfReader(settings);
 
 		const votesReady = Promise.all([
 			loadRememberedVotes(),

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -9577,7 +9577,8 @@ header {
 
 .next-up {
 	display:block;
-	margin:18px -12px 24px;
+	margin:auto -12px 24px;
+	padding-top:18px;
 	font-family:Verdana, Geneva, sans-serif;
 	font-size:11px;
 	color:var(--meta);
@@ -11780,11 +11781,17 @@ ${SUBMIT_FORM_CSS}
 #comments {
 			flex:1 1 auto;
 			min-height:0;
+	display:flex;
+	flex-direction:column;
 	overflow:auto;
 	overflow-x:hidden;
 			overscroll-behavior:contain;
 	padding:12px 12px calc(32px + env(safe-area-inset-bottom, 0px));
 	word-wrap:break-word;
+}
+
+#comments > * {
+	flex:0 0 auto;
 }
 
 .top-level-comments {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -3761,14 +3761,22 @@ button {
 </div>
 </div>`;
 
-		shadow.querySelector("blockquote").textContent = chosen.exact;
+		const quote = shadow.querySelector("blockquote");
 
-		if (!chosen.anchorable) {
+		quote.textContent = chosen.exact || "";
+		quote.hidden = !chosen.exact;
+
+		if (chosen.exact && !chosen.anchorable) {
 			shadow.querySelector(".why").textContent =
 				"Too short to highlight — it will be kept as a note on the page.";
 		}
 
 		const field = shadow.querySelector("textarea");
+
+		field.value = chosen.text || "";
+		shadow.querySelector(".save").textContent = chosen.id
+			? "Save changes"
+			: "Save note";
 
 		shadow.querySelector(".cancel").onclick = () => closeNoteComposer();
 		shadow.querySelector(".save").onclick = () => {
@@ -3801,24 +3809,58 @@ button {
 		}
 
 		const notes = await loadNotes();
+		const written = String(text).trim();
 
-		await saveNotes([
-			...notes,
-			{
-				id: "n" + Date.now().toString(36) + Math.floor(Math.random() * 1e6).toString(36),
-				created: Date.now(),
-				text: String(text).trim(),
-				exact: chosen.anchorable ? chosen.exact : "",
-				prefix: chosen.prefix,
-				suffix: chosen.suffix,
-				page: chosen.page,
-				url: location.href,
-			},
-		]);
+		if (chosen.id) {
+			await saveNotes(
+				notes.map((note) =>
+					note.id === chosen.id
+						? { ...note, text: written, edited: Date.now() }
+						: note,
+				),
+			);
+		} else {
+			await saveNotes([
+				...notes,
+				{
+					id:
+						"n" +
+						Date.now().toString(36) +
+						Math.floor(Math.random() * 1e6).toString(36),
+					created: Date.now(),
+					text: written,
+					exact: chosen.anchorable ? chosen.exact : "",
+					prefix: chosen.prefix,
+					suffix: chosen.suffix,
+					page: chosen.page,
+					url: location.href,
+				},
+			]);
+		}
 
 		closeNoteComposer();
 		window.getSelection()?.removeAllRanges();
 		await reopenForNotes();
+	}
+
+	async function editNote(note, anchor) {
+		if (!note?.id) {
+			return;
+		}
+
+		const rect = anchor?.getBoundingClientRect();
+
+		await openNoteComposer({
+			id: note.id,
+			text: note.text || "",
+			exact: note.exact || "",
+			prefix: note.prefix || "",
+			suffix: note.suffix || "",
+			page: note.page ?? null,
+			anchorable: Boolean(note.exact),
+			left: rect ? rect.left : 24,
+			top: rect ? rect.top : 24,
+		});
 	}
 
 	async function deleteNote(id) {
@@ -4710,9 +4752,11 @@ button {
 	}
 	// #endregion hnewhere-test-export
 
+	// #region hnewhere-test-export
 	function pluralize(value, singular, plural = singular + "s") {
 		return value + " " + (value === 1 ? singular : plural);
 	}
+	// #endregion hnewhere-test-export
 
 	function joinWithAnd(items) {
 		if (items.length < 3) {
@@ -11300,6 +11344,38 @@ ${SUBMIT_FORM_CSS}
 	padding-left:6px;
 }
 
+.notes-section {
+	margin:0 0 6px;
+}
+
+.notes-bookend {
+	display:flex;
+	align-items:center;
+	gap:8px;
+}
+
+.notes-toggle {
+	margin-left:auto;
+	padding:0;
+	border:0;
+	background:none;
+	color:var(--muted);
+	font:inherit;
+	font-size:11px;
+	text-decoration:underline;
+	cursor:pointer;
+}
+
+@media (hover: hover) {
+	.notes-toggle:hover {
+		color:var(--surface-text);
+	}
+}
+
+.notes-section.is-collapsed .notes-body {
+	display:none;
+}
+
 .comment.new-comment {
 	border-left-color:rgba(var(--accent-rgb),.95);
 	transition:border-left-color .9s ease;
@@ -13052,7 +13128,7 @@ ${settingsPanelHTML()}
       <a class="focus-link" href="#">
       focus
       </a>
-		${comment.source === "notes" ? ` | <a class="delete-note-link" href="#">delete</a>` : ""}
+		${comment.source === "notes" ? ` | <a class="edit-note-link" href="#">edit</a> | <a class="delete-note-link" href="#">delete</a>` : ""}
 		${capabilities.vote ? itemActionLinksHTML(commentID, comment.source || "hn") : ""}
 
       <span class="toggle">
@@ -13138,6 +13214,15 @@ ${settingsPanelHTML()}
 		};
 
 		const replyButton = div.querySelector(".reply-link");
+		const editNoteButton = div.querySelector(".edit-note-link");
+
+		if (editNoteButton) {
+			editNoteButton.onclick = (event) => {
+				event.preventDefault();
+				editNote(comment.note, div).catch(console.error);
+			};
+		}
+
 		const deleteNoteButton = div.querySelector(".delete-note-link");
 
 		if (deleteNoteButton) {
@@ -13368,11 +13453,22 @@ ${settingsPanelHTML()}
 
 		const page = discussionsPageTitle(stories);
 
-		const headerElement = renderPageHeader(stories, ui.body, {
-			page,
-			sort: settings.commentSort,
-			onSortChange: () => renderDiscussions(stories, ui),
-		});
+		const localStories = stories.filter(
+			(story) => getSource(story.source)?.local,
+		);
+		const sharedStories = stories.filter(
+			(story) => !getSource(story.source)?.local,
+		);
+
+		const headerElement = renderPageHeader(
+			sharedStories.length ? sharedStories : stories,
+			ui.body,
+			{
+				page,
+				sort: settings.commentSort,
+				onSortChange: () => renderDiscussions(stories, ui),
+			},
+		);
 
 		mountFilterBanner(headerElement, ui);
 
@@ -13419,6 +13515,37 @@ ${settingsPanelHTML()}
 			),
 		);
 
+		if (localStories.length) {
+			const held = notesSection(
+				localStories.reduce(
+					(sum, story) => sum + (story.commentCount || 0),
+					0,
+				),
+			);
+
+			ui.body.insertBefore(held.section, ui.body.querySelector(".page-sort"));
+
+			for (const story of localStories) {
+				const thread = threads[stories.indexOf(story)];
+
+				for (const key of thread.rootKeys) {
+					if (generation !== sidebarGeneration) {
+						return;
+					}
+
+					await renderComment(
+						key,
+						thread,
+						held.body,
+						story,
+						0,
+						collapsedKeys,
+						generation,
+					);
+				}
+			}
+		}
+
 		const context = new Map(
 			stories.map((story, index) => [
 				story.key,
@@ -13427,11 +13554,11 @@ ${settingsPanelHTML()}
 		);
 
 		const entries = blendRoots(
-			stories.map((story, index) => ({
+			sharedStories.map((story) => ({
 				discussionKey: story.key,
-				rootKeys: threads[index].rootKeys,
+				rootKeys: threads[stories.indexOf(story)].rootKeys,
 				story,
-				thread: threads[index],
+				thread: threads[stories.indexOf(story)],
 			})),
 			{
 				sort: settings.commentSort,
@@ -13612,6 +13739,44 @@ ${settingsPanelHTML()}
 
 		return liveDiscussions.has(filter.key) ? [label].filter(Boolean) : [];
 	}
+
+	// #region hnewhere-test-export
+	function notesSection(count) {
+		const section = document.createElement("div");
+		const head = document.createElement("div");
+		const body = document.createElement("div");
+		const toggle = document.createElement("button");
+
+		section.className = "notes-section";
+		section.dataset.notesSection = "1";
+
+		head.className = "live-bookend live-bookend-open notes-bookend";
+		head.innerHTML =
+			`<span class="live-bookend-mark">NOTES</span>` +
+			`<span class="live-bookend-text"><span class="notes-bookend-count"></span></span>`;
+		head.querySelector(".notes-bookend-count").textContent = pluralize(
+			count,
+			"note",
+		);
+
+		toggle.type = "button";
+		toggle.className = "notes-toggle";
+		toggle.textContent = "hide";
+		toggle.setAttribute("aria-expanded", "true");
+		toggle.onclick = () => {
+			const collapsed = section.classList.toggle("is-collapsed");
+
+			toggle.textContent = collapsed ? "show" : "hide";
+			toggle.setAttribute("aria-expanded", collapsed ? "false" : "true");
+		};
+
+		head.appendChild(toggle);
+		body.className = "notes-body";
+		section.append(head, body);
+
+		return { section, body };
+	}
+	// #endregion hnewhere-test-export
 
 	function liveBookend(edge) {
 		const node = document.createElement("div");

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -15899,6 +15899,10 @@ title="Show only this discussion">
 			],
 		});
 
+		if (index.normalizedText) {
+			index.welded = true;
+		}
+
 		return index.normalizedText ? index : null;
 	}
 
@@ -15961,6 +15965,7 @@ title="Show only this discussion">
 			normalizedText: normalized.text,
 			normalizedMap: normalized.map,
 			pageStarts: joined.pageStarts,
+			welded: true,
 
 			rangeAt(matchStart, matchLength) {
 				const rawStart = normalized.map[matchStart];
@@ -15979,13 +15984,29 @@ title="Show only this discussion">
 					matchStart,
 					matchStart + matchLength,
 				);
-				const here = findNormalizedOccurrences(pageIndex.normalizedText, needle);
+				const here = findNormalizedOccurrences(
+					pageIndex.normalizedText,
+					needle,
+					true,
+				);
 
 				if (here.length !== 1) {
 					return null;
 				}
 
-				return createRangeFromMatch(pageIndex, here[0], needle.length);
+				const span = createRangeFromMatch(pageIndex, here[0], needle.length);
+
+				if (!span) {
+					return null;
+				}
+
+				const base = joined.pageStarts[at.pageIndex];
+
+				return {
+					startRaw: base + span.startRaw,
+					endRaw: base + span.endRaw,
+					range: span.range,
+				};
 			},
 		};
 	}
@@ -16089,7 +16110,7 @@ title="Show only this discussion">
 	}
 
 	// #region hnewhere-test-export
-	function findNormalizedOccurrences(haystack, needle) {
+	function findNormalizedOccurrences(haystack, needle, welded = false) {
 		const matches = [];
 
 		if (!haystack || !needle) {
@@ -16110,7 +16131,7 @@ title="Show only this discussion">
 				index + needle.length === haystack.length ||
 				haystack[index + needle.length] === " ";
 
-			if (before && after) {
+			if (welded || (before && after)) {
 				matches.push(index);
 			}
 
@@ -16121,7 +16142,7 @@ title="Show only this discussion">
 	}
 
 	function resolveRawPoint(index, rawOffset, bias) {
-		if (!index.rawPoints.length) {
+		if (!index.rawPoints?.length) {
 			return null;
 		}
 
@@ -16269,6 +16290,7 @@ title="Show only this discussion">
 		const matches = findNormalizedOccurrences(
 			articleIndex.normalizedText,
 			normalized,
+			articleIndex.welded,
 		);
 		let at = null;
 		let context = null;
@@ -16346,6 +16368,7 @@ title="Show only this discussion">
 			const matches = findNormalizedOccurrences(
 				articleIndex.normalizedText,
 				variant.normalized,
+				articleIndex.welded,
 			);
 
 			if (!matches.length) {
@@ -16469,7 +16492,28 @@ title="Show only this discussion">
 	}
 
 	// #region hnewhere-test-export
+	function dedupeGroupComments(groups) {
+		for (const group of groups) {
+			const seen = new Set();
+
+			group.comments = group.comments.filter((comment) => {
+				if (seen.has(comment.commentId)) {
+					return false;
+				}
+
+				seen.add(comment.commentId);
+				return true;
+			});
+		}
+
+		return groups;
+	}
+
 	function mergeOverlappingGroups(groups, articleIndex) {
+		if (!articleIndex.rawPoints) {
+			return dedupeGroupComments([...groups]);
+		}
+
 		const sorted = [...groups].sort(
 			(a, b) => a.startRaw - b.startRaw || a.endRaw - b.endRaw,
 		);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -240,7 +240,7 @@
 		return migrated;
 	}
 
-	function normalizeSourceSettings(stored, registeredIds, defaults = {}) {
+	function normalizeSourceSettings(stored, registeredIds) {
 		const source =
 			stored && typeof stored === "object" && !Array.isArray(stored)
 				? stored
@@ -248,31 +248,14 @@
 		const normalized = {};
 
 		for (const id of registeredIds) {
-			normalized[id] =
-				id in source ? Boolean(source[id]) : Boolean(defaults[id]);
+			normalized[id] = Boolean(source[id]);
 		}
 
 		return normalized;
 	}
 
-	function sourceDefaults() {
-		const defaults = {};
-
-		for (const source of SOURCES.values()) {
-			if (source.defaultOn) {
-				defaults[source.id] = true;
-			}
-		}
-
-		return defaults;
-	}
-
 	function enabledSourceIds(settings, registeredIds) {
-		const normalized = normalizeSourceSettings(
-			settings?.sources,
-			registeredIds,
-			sourceDefaults(),
-		);
+		const normalized = normalizeSourceSettings(settings?.sources, registeredIds);
 
 		return registeredIds.filter((id) => normalized[id]);
 	}
@@ -363,6 +346,7 @@
 	const DEFAULT_SETTINGS = {
 		annotations: false,
 		annotationsWhenSidebarClosed: false,
+		notepad: true,
 		pdfReader: false,
 		autoOpenSidebar: false,
 		autoOpenSidebarOnlyFromHN: false,
@@ -2714,10 +2698,6 @@ ${
 		return typeof source?.frontPage === "function";
 	}
 
-	function matrixSources() {
-		return [...SOURCES.values()].filter((source) => !source.local);
-	}
-
 	registerSource({
 		id: "hn",
 		origins: ["news.ycombinator.com"],
@@ -3515,11 +3495,22 @@ ${
 		return NOTES_PREFIX + ref.kind + ":" + ref.id;
 	}
 
+	function noteSeconds(value) {
+		const number = Number(value) || 0;
+
+		return number > 1e11 ? Math.floor(number / 1000) : number;
+	}
+
 	function keptNotes(stored) {
 		const notes = Array.isArray(stored?.notes) ? stored.notes : [];
 
 		return notes
 			.filter((note) => note?.id && String(note.text ?? "").trim())
+			.map((note) => ({
+				...note,
+				created: noteSeconds(note.created),
+				edited: note.edited ? noteSeconds(note.edited) : note.edited,
+			}))
 			.sort((a, b) => (a.created || 0) - (b.created || 0));
 	}
 
@@ -3547,6 +3538,7 @@ ${
 	function noteComment(note, discussion) {
 		return {
 			source: "notes",
+			local: true,
 			key: sourceKey("notes", note.id),
 			id: note.id,
 			discussionKey: discussion?.key,
@@ -3570,16 +3562,17 @@ ${
 
 		return {
 			source: "notes",
+			local: true,
 			key: sourceKey("notes", "notes"),
 			id: "notes",
-			title: "Backchannel local notes",
+			title: "Notepad",
 			author: "",
 			score: null,
 			commentCount: notes.length,
 			createdAt: Math.max(...notes.map((note) => note.created || 0)),
 			permalink: null,
 			articleURL,
-			label: "Backchannel local notes",
+			label: "Notepad",
 			collective: true,
 			bodyHTML: "",
 			rootKeys: notes.map((note) => sourceKey("notes", note.id)),
@@ -3896,7 +3889,7 @@ button {
 			...(changed ? reanchoredNote(note, parsed) : note),
 			text: parsed.text,
 			exact: parsed.exact,
-			edited: Date.now(),
+			edited: Math.floor(Date.now() / 1000),
 		};
 	}
 
@@ -3972,7 +3965,7 @@ button {
 			}
 		};
 
-		row.append(why, cancel, save);
+		row.append(save, cancel, why);
 		editor.append(field, row);
 
 		return { editor, field };
@@ -4034,12 +4027,15 @@ button {
 	}
 
 	function startNotepadDraft(section, body) {
-		openNotepad(section);
+		const add = section.querySelector(".notepad-add");
+		const open = body.querySelector(".note-editor-draft");
 
-		if (body.querySelector(".note-editor")) {
-			body.querySelector(".note-editor-field")?.focus();
+		if (open) {
+			closeNotepadDraft(section, body);
 			return;
 		}
+
+		openNotepad(section);
 
 		const held = inlineNoteEditor(null, {
 			canAnchor: (exact) => Boolean(anchorNoteQuote(exact)),
@@ -4047,16 +4043,40 @@ button {
 			onSave: (parsed) => {
 				writeNote(parsed).catch(console.error);
 			},
-			onClose: () => {
-				held.editor.remove();
-				settleNotepad(body.firstElementChild || body);
-			},
+			onClose: () => closeNotepadDraft(section, body),
 		});
 
 		held.editor.classList.add("note-editor-draft");
 		body.prepend(held.editor);
-		held.field.focus();
-		settleNotepad(held.editor);
+		add?.classList.add("is-open");
+		add?.setAttribute("aria-expanded", "true");
+
+		requestAnimationFrame(() => {
+			held.editor.classList.add("is-open");
+			held.editor.style.maxHeight = `${held.editor.scrollHeight}px`;
+			settleNotepad(held.editor);
+			held.field.focus();
+		});
+	}
+
+	function closeNotepadDraft(section, body) {
+		const add = section.querySelector(".notepad-add");
+		const draft = body.querySelector(".note-editor-draft");
+
+		add?.classList.remove("is-open");
+		add?.setAttribute("aria-expanded", "false");
+
+		if (!draft) {
+			return;
+		}
+
+		draft.style.maxHeight = "0px";
+		draft.classList.remove("is-open");
+
+		window.setTimeout(() => {
+			draft.remove();
+			settleNotepad(body.firstElementChild || body);
+		}, 220);
 	}
 
 	async function writeNote(parsed) {
@@ -4074,7 +4094,7 @@ button {
 						"n" +
 						Date.now().toString(36) +
 						Math.floor(Math.random() * 1e6).toString(36),
-					created: Date.now(),
+					created: Math.floor(Date.now() / 1000),
 					url: location.href,
 				},
 				parsed,
@@ -4110,15 +4130,7 @@ button {
 			return;
 		}
 
-		const found = (await getSource("notes")?.discover(pageAddress())) || [];
-		const others = renderedDiscussions.filter((story) => story.source !== "notes");
-		const next = [...others, ...found];
-
-		if (!next.length) {
-			return;
-		}
-
-		await renderDiscussions(next, sidebarUI);
+		await renderDiscussions(renderedDiscussions, sidebarUI);
 		await refreshArticleAnnotations();
 	}
 
@@ -4173,6 +4185,25 @@ button {
 		});
 	}
 
+	// #region hnewhere-test-export
+	function notesThread(discussion) {
+		const byKey = new Map(
+			(discussion.notes || []).map((note) => [
+				sourceKey("notes", note.id),
+				noteComment(note, discussion),
+			]),
+		);
+
+		return {
+			rootKeys: [...byKey.keys()],
+
+			async getComment(key) {
+				return byKey.get(key) || null;
+			},
+		};
+	}
+	// #endregion hnewhere-test-export
+
 	function noteDocumentRefForPage() {
 		return noteDocumentRef(pdfViewerApp()?.pdfDocument?.fingerprints?.[0]);
 	}
@@ -4210,51 +4241,6 @@ button {
 
 		await save(NOTES_INDEX_KEY, entries);
 	}
-
-	registerSource({
-		id: "notes",
-		origins: [],
-		label: "Backchannel local notes",
-		shortLabel: "Notes",
-		local: true,
-		defaultOn: true,
-		ageLabel: "Last note",
-		threadArrivesWhole: true,
-		caveat:
-			"Stays on this device. Nothing is sent anywhere, and no host is contacted.",
-		capabilities: { vote: false, reply: false, submit: false },
-
-		profileURL: () => null,
-
-		async discover(url) {
-			const collective = notesCollective(await loadNotes(), url);
-
-			return collective ? [collective] : [];
-		},
-
-		async loadThread(discussion) {
-			const byKey = new Map(
-				(discussion.notes || []).map((note) => [
-					sourceKey("notes", note.id),
-					noteComment(note, discussion),
-				]),
-			);
-			const rootTimes = new Map();
-
-			for (const [key, comment] of byKey) {
-				rootTimes.set(key, comment.createdAt);
-			}
-
-			return {
-				rootKeys: [...byKey.keys()],
-				rootTimes,
-
-				async getComment(key) {
-					return byKey.get(key) || null;
-				},
-			};
-		},
-	});
 
 	const MASTODON_INSTANCE = "https://mastodon.social";
 	const TOOTFINDER = "https://www.tootfinder.ch";
@@ -10587,6 +10573,17 @@ allowing highlighting and annotation directly onto the PDF.
 </div>
 
 <div class="settings-group">
+<label class="settings-option">
+<input id="setting-notepad" data-setting="notepad" type="checkbox">
+<span>Enable notepad</span>
+</label>
+<div class="settings-option-hint">
+Write your own notes on any page or PDF, on a passage you select or on the page
+as a whole. They stay on this device and are never sent anywhere.
+</div>
+</div>
+
+<div class="settings-group">
 <div class="settings-field">
 <div class="settings-field-label">Theme</div>
 <div class="segmented">
@@ -10650,7 +10647,7 @@ ${sourceListHTML({ idPrefix: "setting-source-" })}
 <div class="source-matrix-caption">What each source supports</div>
 <div class="source-matrix-scroll">
 <table class="source-matrix">
-<thead><tr><th></th>${matrixSources().map((source) => `<th>${escapeHTML(source.shortLabel || source.label)}</th>`).join("")}</tr></thead>
+<thead><tr><th></th>${[...SOURCES.values()].map((source) => `<th>${escapeHTML(source.shortLabel || source.label)}</th>`).join("")}</tr></thead>
 <tbody>
 ${[
 	["Read", () => true],
@@ -10662,7 +10659,9 @@ ${[
 	["Flag", (source) => Boolean(source.capabilities.flag)],
 ]
 	.map(
-		([label, supported]) => `<tr><th>${escapeHTML(label)}</th>${matrixSources()
+		([label, supported]) => `<tr><th>${escapeHTML(label)}</th>${[
+			...SOURCES.values(),
+		]
 			.map((source) => {
 				const yes = Boolean(supported(source));
 				return `<td class="${yes ? "yes" : "no"}" data-capability-source="${escapeHTML(source.id)}" aria-label="${yes ? "yes" : "no"}">${yes ? "&check;" : "&ndash;"}</td>`;
@@ -10734,6 +10733,7 @@ ${[
 				"#setting-annotations-closed",
 			),
 			pdfReader: shadow.querySelector("#setting-pdf-reader"),
+			notepad: shadow.querySelector("#setting-notepad"),
 			autoOpenSidebarOnlyFromHN: shadow.querySelector(
 				"#setting-auto-open-only-from-hn",
 			),
@@ -11650,6 +11650,21 @@ ${SUBMIT_FORM_CSS}
 	transition:max-height .22s ease, opacity .18s ease;
 }
 
+.notepad-add.is-open {
+	text-decoration:underline;
+}
+
+.note-editor-draft {
+	overflow:hidden;
+	max-height:0;
+	opacity:0;
+	transition:max-height .22s ease, opacity .18s ease;
+}
+
+.note-editor-draft.is-open {
+	opacity:1;
+}
+
 .notepad-section.is-collapsed .notepad-body {
 	opacity:0;
 }
@@ -11659,7 +11674,7 @@ ${SUBMIT_FORM_CSS}
 }
 
 .note-editor {
-	margin:4px 0 0;
+	margin:8px 0 2px;
 }
 
 .note-editor-field {
@@ -11677,40 +11692,49 @@ ${SUBMIT_FORM_CSS}
 
 .note-editor-row {
 	display:flex;
-	gap:8px;
-	align-items:baseline;
-	justify-content:flex-end;
-	margin-top:5px;
+	gap:10px;
+	align-items:center;
+	justify-content:flex-start;
+	margin-top:6px;
 }
 
 .note-editor-why {
-	margin-right:auto;
 	color:var(--meta);
 	font-size:11px;
 }
 
-.note-editor-row button {
+.note-editor-cancel {
 	padding:0;
 	border:0;
 	background:none;
-	color:var(--muted);
+	color:var(--meta);
 	font:inherit;
 	font-size:11px;
-	text-decoration:underline;
+	text-decoration:none;
 	cursor:pointer;
 }
 
 .note-editor-save {
+	padding:3px 10px;
+	border:0;
+	border-radius:5px;
+	background:rgba(var(--accent-rgb),.95);
+	color:var(--header-text);
+	font:inherit;
+	font-size:11px;
 	font-weight:600;
+	cursor:pointer;
 }
-
-
 
 @media (hover: hover) {
-	.note-editor-row button:hover {
-		color:var(--surface-text);
+	.note-editor-cancel:hover {
+		text-decoration:underline;
 	}
 }
+
+
+
+
 
 .comment.new-comment {
 	border-left-color:rgba(var(--accent-rgb),.95);
@@ -13412,19 +13436,19 @@ ${settingsPanelHTML()}
 		div.dataset.commentId = comment.key;
 		div.dataset.storyId = String(storyID);
 
-		if (!getSource(comment.source)?.local && isNewComment(comment, seenTime)) {
+		if (!comment.local && isNewComment(comment, seenTime)) {
 			div.classList.add("new-comment");
 		}
 
 		const replies = comment.replyKeys;
 		const commentID = String(comment.id);
 		const capabilities = getSource(comment.source)?.capabilities || {};
-		const isLocalSource = Boolean(getSource(comment.source)?.local);
+		const isLocalSource = Boolean(comment.local);
 		const threadCanVote = renderedSourcesCanVote();
 
 		div.innerHTML = `
       <div class="comment-layout">
-      <span class="comment-vote-slot${threadCanVote ? "" : " comment-vote-slot-empty"}">
+      <span class="comment-vote-slot${threadCanVote && !isLocalSource ? "" : " comment-vote-slot-empty"}">
       <span class="comment-vote-controls vote-controls hidden"
       data-hn-vote-source="${escapeHTML(String(comment.source || "hn"))}"
       data-hn-vote-story-id="${escapeHTML(String(storyID))}"
@@ -13783,32 +13807,18 @@ ${settingsPanelHTML()}
 		const liveNow = Math.floor(Date.now() / 1000);
 
 		stories.forEach((story, index) => {
-			if (
-				!getSource(story.source)?.local &&
-				isDiscussionLive(threads[index], liveNow)
-			) {
+			if (!story.local && isDiscussionLive(threads[index], liveNow)) {
 				liveDiscussions.set(story.key, story.baseLabel || story.label || "");
 			}
 		});
 
 		const page = discussionsPageTitle(stories);
 
-		const localStories = stories.filter(
-			(story) => getSource(story.source)?.local,
-		);
-		const sharedStories = stories.filter(
-			(story) => !getSource(story.source)?.local,
-		);
-
-		const headerElement = renderPageHeader(
-			sharedStories.length ? sharedStories : stories,
-			ui.body,
-			{
-				page,
-				sort: settings.commentSort,
-				onSortChange: () => renderDiscussions(stories, ui),
-			},
-		);
+		const headerElement = renderPageHeader(stories, ui.body, {
+			page,
+			sort: settings.commentSort,
+			onSortChange: () => renderDiscussions(stories, ui),
+		});
 
 		mountFilterBanner(headerElement, ui);
 
@@ -13825,7 +13835,7 @@ ${settingsPanelHTML()}
 
 		const disambiguating = stories.length > 1;
 
-		for (const story of sharedStories) {
+		for (const story of stories) {
 			const canVote = Boolean(getSource(story.source)?.capabilities.vote);
 			const canReply = Boolean(getSource(story.source)?.capabilities.reply);
 			const resolved = storyTitle(story, page, disambiguating);
@@ -13855,19 +13865,18 @@ ${settingsPanelHTML()}
 			),
 		);
 
-		const notesOn = enabledSourceIds(settings, registeredSourceIds()).includes(
-			"notes",
-		);
+		const notes = settings.notepad ? await loadNotes() : [];
+		const notesDiscussion = notesCollective(notes, pageAddress());
 
-		if (localStories.length || notesOn) {
+		if (settings.notepad) {
 			const held = notesSection({
 				onAdd: () => startNotepadDraft(held.section, held.body),
 			});
 
 			ui.body.insertBefore(held.section, ui.body.querySelector(".page-sort"));
 
-			for (const story of localStories) {
-				const thread = threads[stories.indexOf(story)];
+			if (notesDiscussion) {
+				const thread = notesThread(notesDiscussion);
 
 				for (const key of thread.rootKeys) {
 					if (generation !== sidebarGeneration) {
@@ -13878,7 +13887,7 @@ ${settingsPanelHTML()}
 						key,
 						thread,
 						held.body,
-						story,
+						notesDiscussion,
 						0,
 						collapsedKeys,
 						generation,
@@ -13897,11 +13906,11 @@ ${settingsPanelHTML()}
 		);
 
 		const entries = blendRoots(
-			sharedStories.map((story) => ({
+			stories.map((story, index) => ({
 				discussionKey: story.key,
-				rootKeys: threads[stories.indexOf(story)].rootKeys,
+				rootKeys: threads[index].rootKeys,
 				story,
-				thread: threads[stories.indexOf(story)],
+				thread: threads[index],
 			})),
 			{
 				sort: settings.commentSort,
@@ -17780,7 +17789,7 @@ title="Show only this discussion">
 
 				group.comments.push({
 					commentId: rendered.id,
-					source: rendered.source,
+					local: rendered.local,
 					element: rendered.element,
 					textElement: rendered.textElement,
 					author: rendered.author,
@@ -18616,7 +18625,7 @@ title="Show only this discussion">
 	function decorateSidebarMatches(controller) {
 		for (const group of controller.groups) {
 			for (const comment of group.comments) {
-				if (getSource(comment.source)?.local) {
+				if (comment.local) {
 					continue;
 				}
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -240,7 +240,7 @@
 		return migrated;
 	}
 
-	function normalizeSourceSettings(stored, registeredIds) {
+	function normalizeSourceSettings(stored, registeredIds, defaults = {}) {
 		const source =
 			stored && typeof stored === "object" && !Array.isArray(stored)
 				? stored
@@ -248,14 +248,31 @@
 		const normalized = {};
 
 		for (const id of registeredIds) {
-			normalized[id] = Boolean(source[id]);
+			normalized[id] =
+				id in source ? Boolean(source[id]) : Boolean(defaults[id]);
 		}
 
 		return normalized;
 	}
 
+	function sourceDefaults() {
+		const defaults = {};
+
+		for (const source of SOURCES.values()) {
+			if (source.defaultOn) {
+				defaults[source.id] = true;
+			}
+		}
+
+		return defaults;
+	}
+
 	function enabledSourceIds(settings, registeredIds) {
-		const normalized = normalizeSourceSettings(settings?.sources, registeredIds);
+		const normalized = normalizeSourceSettings(
+			settings?.sources,
+			registeredIds,
+			sourceDefaults(),
+		);
 
 		return registeredIds.filter((id) => normalized[id]);
 	}
@@ -2696,6 +2713,10 @@ ${
 		return typeof source?.frontPage === "function";
 	}
 
+	function matrixSources() {
+		return [...SOURCES.values()].filter((source) => !source.local);
+	}
+
 	registerSource({
 		id: "hn",
 		origins: ["news.ycombinator.com"],
@@ -3468,6 +3489,183 @@ ${
 				rootTimes,
 				async getComment(key) {
 					return index.byKey.get(key) || null;
+				},
+			};
+		},
+	});
+
+	// -------------------------
+	// Notes you make yourself
+	// -------------------------
+
+	// #region hnewhere-test-export
+	const NOTES_PREFIX = "HNewhere:notes:";
+	const NOTES_INDEX_KEY = "HNewhere:notes_index";
+	const NOTE_CONTEXT_CHARS = 32;
+	const NOTES_PER_DOCUMENT = 200;
+
+	function noteDocumentRef(fingerprint = null) {
+		return fingerprint
+			? { kind: "pdf", id: String(fingerprint) }
+			: { kind: "url", id: normalizeURL(location.href) || location.href };
+	}
+
+	function noteStorageKey(ref) {
+		return NOTES_PREFIX + ref.kind + ":" + ref.id;
+	}
+
+	function keptNotes(stored) {
+		const notes = Array.isArray(stored?.notes) ? stored.notes : [];
+
+		return notes
+			.filter((note) => note?.id && String(note.text ?? "").trim())
+			.sort((a, b) => (a.created || 0) - (b.created || 0));
+	}
+
+	function noteTextHTML(text) {
+		return String(text || "")
+			.split(/\n{2,}/)
+			.map((part) => part.trim())
+			.filter(Boolean)
+			.map((part) => `<p>${escapeHTML(part).replace(/\n/g, "<br>")}</p>`)
+			.join("");
+	}
+
+	function noteBodyHTML(note) {
+		const context =
+			(note.prefix ? ` data-hnewhere-prefix="${escapeHTML(note.prefix)}"` : "") +
+			(note.suffix ? ` data-hnewhere-suffix="${escapeHTML(note.suffix)}"` : "");
+
+		return (
+			(note.exact
+				? `<blockquote data-hnewhere-exact="1"${context}>${escapeHTML(note.exact)}</blockquote>`
+				: "") + noteTextHTML(note.text)
+		);
+	}
+
+	function noteComment(note, discussion) {
+		return {
+			source: "notes",
+			key: sourceKey("notes", note.id),
+			id: note.id,
+			discussionKey: discussion?.key,
+			parentKey: null,
+			author: "you",
+			authorName: "You",
+			bodyHTML: noteBodyHTML(note),
+			score: null,
+			createdAt: note.created || 0,
+			isOP: false,
+			deleted: false,
+			replyKeys: [],
+			note,
+		};
+	}
+
+	function notesCollective(notes, articleURL) {
+		if (!notes.length) {
+			return null;
+		}
+
+		return {
+			source: "notes",
+			key: sourceKey("notes", "notes"),
+			id: "notes",
+			title: "Your notes",
+			author: "",
+			score: null,
+			commentCount: notes.length,
+			createdAt: Math.max(...notes.map((note) => note.created || 0)),
+			permalink: null,
+			articleURL,
+			label: "Your notes",
+			collective: true,
+			bodyHTML: "",
+			rootKeys: notes.map((note) => sourceKey("notes", note.id)),
+			rootTimes: notes.map((note) => note.created || 0),
+			notes,
+		};
+	}
+	// #endregion hnewhere-test-export
+
+	function noteDocumentRefForPage() {
+		return noteDocumentRef(pdfViewerApp()?.pdfDocument?.fingerprints?.[0]);
+	}
+
+	async function loadNotes(ref = noteDocumentRefForPage()) {
+		return keptNotes(await load(noteStorageKey(ref), null));
+	}
+
+	async function saveNotes(notes, ref = noteDocumentRefForPage()) {
+		const kept = notes.slice(-NOTES_PER_DOCUMENT);
+
+		await save(noteStorageKey(ref), { version: 1, notes: kept });
+		await rememberNotedDocument(ref, kept.length);
+
+		return kept;
+	}
+
+	async function rememberNotedDocument(ref, count) {
+		const stored = await load(NOTES_INDEX_KEY, []);
+		const entries = (Array.isArray(stored) ? stored : []).filter(
+			(entry) => entry?.key !== noteStorageKey(ref),
+		);
+
+		if (count > 0) {
+			entries.push({
+				key: noteStorageKey(ref),
+				kind: ref.kind,
+				id: ref.id,
+				url: location.href,
+				title: pageTitle(),
+				count,
+				updated: Date.now(),
+			});
+		}
+
+		await save(NOTES_INDEX_KEY, entries);
+	}
+
+	registerSource({
+		id: "notes",
+		origins: [],
+		label: "Your notes",
+		shortLabel: "Notes",
+		local: true,
+		defaultOn: true,
+		ageLabel: "Last note",
+		threadArrivesWhole: true,
+		caveat:
+			"Stays on this device. Nothing is sent anywhere, and no host is contacted.",
+		capabilities: { vote: false, reply: false, submit: false },
+
+		profileURL: () => null,
+
+		async discover(url) {
+			const collective = notesCollective(await loadNotes(), url);
+
+			return collective ? [collective] : [];
+		},
+
+		async loadThread(discussion) {
+			const byKey = new Map(
+				(discussion.notes || []).map((note) => [
+					sourceKey("notes", note.id),
+					noteComment(note, discussion),
+				]),
+			);
+			const rootTimes = new Map();
+
+			for (const [key, comment] of byKey) {
+				rootTimes.set(key, comment.createdAt);
+			}
+
+			return {
+				rootKeys: [...byKey.keys()],
+				rootTimes,
+
+				async getComment(key) {
+					return byKey.get(key) || null;
 				},
 			};
 		},
@@ -9865,7 +10063,7 @@ ${sourceListHTML({ idPrefix: "setting-source-" })}
 <div class="source-matrix-caption">What each source supports</div>
 <div class="source-matrix-scroll">
 <table class="source-matrix">
-<thead><tr><th></th>${[...SOURCES.values()].map((source) => `<th>${escapeHTML(source.shortLabel || source.label)}</th>`).join("")}</tr></thead>
+<thead><tr><th></th>${matrixSources().map((source) => `<th>${escapeHTML(source.shortLabel || source.label)}</th>`).join("")}</tr></thead>
 <tbody>
 ${[
 	["Read", () => true],
@@ -9877,9 +10075,7 @@ ${[
 	["Flag", (source) => Boolean(source.capabilities.flag)],
 ]
 	.map(
-		([label, supported]) => `<tr><th>${escapeHTML(label)}</th>${[
-			...SOURCES.values(),
-		]
+		([label, supported]) => `<tr><th>${escapeHTML(label)}</th>${matrixSources()
 			.map((source) => {
 				const yes = Boolean(supported(source));
 				return `<td class="${yes ? "yes" : "no"}" data-capability-source="${escapeHTML(source.id)}" aria-label="${yes ? "yes" : "no"}">${yes ? "&check;" : "&ndash;"}</td>`;

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -13719,6 +13719,7 @@ ${settingsPanelHTML()}
 			const hidden = content.classList.toggle("hidden");
 
 			toggle.textContent = hidden ? "[+]" : "[–]";
+			settleNotepad(div);
 
 			await toggleCollapsed(comment.key, hidden);
 		};
@@ -15924,6 +15925,7 @@ title="Show only this discussion">
 					rendered.contentElement.classList.add("hidden");
 					rendered.toggleElement.textContent = "[+]";
 					delete rendered.element.dataset.filterExpanded;
+					settleNotepad(rendered.element);
 				}
 			}
 
@@ -18607,6 +18609,7 @@ title="Show only this discussion">
 					rendered.contentElement.classList.remove("hidden");
 					rendered.toggleElement.textContent = "[–]";
 					rendered.element.dataset.filterExpanded = "1";
+					settleNotepad(rendered.element);
 				}
 			}
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -3773,10 +3773,7 @@ button {
 
 		const field = shadow.querySelector("textarea");
 
-		field.value = chosen.text || "";
-		shadow.querySelector(".save").textContent = chosen.id
-			? "Save changes"
-			: "Save note";
+
 
 		shadow.querySelector(".cancel").onclick = () => closeNoteComposer();
 		shadow.querySelector(".save").onclick = () => {
@@ -3811,56 +3808,111 @@ button {
 		const notes = await loadNotes();
 		const written = String(text).trim();
 
-		if (chosen.id) {
-			await saveNotes(
-				notes.map((note) =>
-					note.id === chosen.id
-						? { ...note, text: written, edited: Date.now() }
-						: note,
-				),
-			);
-		} else {
-			await saveNotes([
-				...notes,
-				{
-					id:
-						"n" +
-						Date.now().toString(36) +
-						Math.floor(Math.random() * 1e6).toString(36),
-					created: Date.now(),
-					text: written,
-					exact: chosen.anchorable ? chosen.exact : "",
-					prefix: chosen.prefix,
-					suffix: chosen.suffix,
-					page: chosen.page,
-					url: location.href,
-				},
-			]);
-		}
+		await saveNotes([
+			...notes,
+			{
+				id:
+					"n" +
+					Date.now().toString(36) +
+					Math.floor(Math.random() * 1e6).toString(36),
+				created: Date.now(),
+				text: written,
+				exact: chosen.anchorable ? chosen.exact : "",
+				prefix: chosen.prefix,
+				suffix: chosen.suffix,
+				page: chosen.page,
+				url: location.href,
+			},
+		]);
 
 		closeNoteComposer();
 		window.getSelection()?.removeAllRanges();
 		await reopenForNotes();
 	}
 
-	async function editNote(note, anchor) {
-		if (!note?.id) {
+	// #region hnewhere-test-export
+	function inlineNoteEditor(note, { onSave, onClose }) {
+		const editor = document.createElement("div");
+		const field = document.createElement("textarea");
+		const row = document.createElement("div");
+		const save = document.createElement("button");
+		const cancel = document.createElement("button");
+
+		editor.className = "note-editor";
+		field.className = "note-editor-field";
+		field.value = note?.text || "";
+		field.setAttribute("aria-label", "Edit your note");
+
+		row.className = "note-editor-row";
+		cancel.type = "button";
+		cancel.className = "note-editor-cancel";
+		cancel.textContent = "cancel";
+		save.type = "button";
+		save.className = "note-editor-save";
+		save.textContent = "save";
+
+		const commit = () => {
+			if (String(field.value || "").trim()) {
+				onSave(field.value);
+			}
+		};
+
+		cancel.onclick = onClose;
+		save.onclick = commit;
+		field.onkeydown = (event) => {
+			if (event.key === "Escape") {
+				onClose();
+			}
+
+			if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+				commit();
+			}
+		};
+
+		row.append(cancel, save);
+		editor.append(field, row);
+
+		return { editor, field };
+	}
+	// #endregion hnewhere-test-export
+
+	function startInlineNoteEdit(div, note) {
+		const text = div.querySelector(".text");
+
+		if (!text || div.querySelector(".note-editor")) {
 			return;
 		}
 
-		const rect = anchor?.getBoundingClientRect();
-
-		await openNoteComposer({
-			id: note.id,
-			text: note.text || "",
-			exact: note.exact || "",
-			prefix: note.prefix || "",
-			suffix: note.suffix || "",
-			page: note.page ?? null,
-			anchorable: Boolean(note.exact),
-			left: rect ? rect.left : 24,
-			top: rect ? rect.top : 24,
+		const held = inlineNoteEditor(note, {
+			onSave: (value) => {
+				updateNote(note.id, value).catch(console.error);
+			},
+			onClose: () => {
+				held.editor.remove();
+				text.hidden = false;
+			},
 		});
+
+		text.hidden = true;
+		text.after(held.editor);
+		held.field.focus();
+	}
+
+	async function updateNote(id, text) {
+		const written = String(text || "").trim();
+
+		if (!written) {
+			return;
+		}
+
+		const notes = await loadNotes();
+
+		await saveNotes(
+			notes.map((note) =>
+				note.id === id ? { ...note, text: written, edited: Date.now() } : note,
+			),
+		);
+		await reopenForNotes();
 	}
 
 	async function deleteNote(id) {
@@ -11344,17 +11396,43 @@ ${SUBMIT_FORM_CSS}
 	padding-left:6px;
 }
 
-.notes-section {
+.notepad-section {
 	margin:0 0 6px;
 }
 
-.notes-bookend {
+.notepad-rule {
 	display:flex;
 	align-items:center;
-	gap:8px;
+	gap:6px;
+	margin:0 -12px;
+	padding:10px 12px 0;
+	font-size:11px;
+	color:var(--meta);
+	line-height:13px;
 }
 
-.notes-toggle {
+.notepad-rule::after {
+	content:"";
+	flex:1 0 24px;
+	height:1px;
+	background:var(--surface-border);
+}
+
+.notepad-rule-close {
+	padding-top:8px;
+}
+
+.notepad-mark {
+	padding:0 4px;
+	border-radius:3px;
+	font-size:10px;
+	font-weight:600;
+	letter-spacing:.04em;
+	color:var(--surface-text);
+	background:var(--hover-tint);
+}
+
+.notepad-toggle {
 	margin-left:auto;
 	padding:0;
 	border:0;
@@ -11367,13 +11445,63 @@ ${SUBMIT_FORM_CSS}
 }
 
 @media (hover: hover) {
-	.notes-toggle:hover {
+	.notepad-toggle:hover {
 		color:var(--surface-text);
 	}
 }
 
-.notes-section.is-collapsed .notes-body {
-	display:none;
+.notepad-body {
+	overflow:hidden;
+	transition:max-height .22s ease, opacity .18s ease;
+}
+
+.notepad-section.is-collapsed .notepad-body {
+	opacity:0;
+}
+
+.note-editor {
+	margin:4px 0 0;
+}
+
+.note-editor-field {
+	width:100%;
+	min-height:56px;
+	box-sizing:border-box;
+	padding:6px 7px;
+	border:1px solid var(--surface-border);
+	border-radius:6px;
+	background:var(--surface);
+	color:var(--surface-text);
+	font:inherit;
+	resize:vertical;
+}
+
+.note-editor-row {
+	display:flex;
+	gap:8px;
+	justify-content:flex-end;
+	margin-top:5px;
+}
+
+.note-editor-row button {
+	padding:0;
+	border:0;
+	background:none;
+	color:var(--muted);
+	font:inherit;
+	font-size:11px;
+	text-decoration:underline;
+	cursor:pointer;
+}
+
+.note-editor-save {
+	font-weight:600;
+}
+
+@media (hover: hover) {
+	.note-editor-row button:hover {
+		color:var(--surface-text);
+	}
 }
 
 .comment.new-comment {
@@ -13083,6 +13211,7 @@ ${settingsPanelHTML()}
 		const replies = comment.replyKeys;
 		const commentID = String(comment.id);
 		const capabilities = getSource(comment.source)?.capabilities || {};
+		const isLocalSource = Boolean(getSource(comment.source)?.local);
 		const threadCanVote = renderedSourcesCanVote();
 
 		div.innerHTML = `
@@ -13123,12 +13252,10 @@ ${settingsPanelHTML()}
 					: ""
 			}
 
-      |
+      ${isLocalSource ? "" : "|"}
 
-      <a class="focus-link" href="#">
-      focus
-      </a>
-		${comment.source === "notes" ? ` | <a class="edit-note-link" href="#">edit</a> | <a class="delete-note-link" href="#">delete</a>` : ""}
+      ${isLocalSource ? "" : `<a class="focus-link" href="#">focus</a>`}
+		${isLocalSource ? `<a class="edit-note-link" href="#">edit</a> | <a class="delete-note-link" href="#">delete</a>` : ""}
 		${capabilities.vote ? itemActionLinksHTML(commentID, comment.source || "hn") : ""}
 
       <span class="toggle">
@@ -13219,7 +13346,7 @@ ${settingsPanelHTML()}
 		if (editNoteButton) {
 			editNoteButton.onclick = (event) => {
 				event.preventDefault();
-				editNote(comment.note, div).catch(console.error);
+				startInlineNoteEdit(div, comment.note);
 			};
 		}
 
@@ -13485,7 +13612,7 @@ ${settingsPanelHTML()}
 
 		const disambiguating = stories.length > 1;
 
-		for (const story of stories) {
+		for (const story of sharedStories) {
 			const canVote = Boolean(getSource(story.source)?.capabilities.vote);
 			const canReply = Boolean(getSource(story.source)?.capabilities.reply);
 			const resolved = storyTitle(story, page, disambiguating);
@@ -13516,12 +13643,7 @@ ${settingsPanelHTML()}
 		);
 
 		if (localStories.length) {
-			const held = notesSection(
-				localStories.reduce(
-					(sum, story) => sum + (story.commentCount || 0),
-					0,
-				),
-			);
+			const held = notesSection();
 
 			ui.body.insertBefore(held.section, ui.body.querySelector(".page-sort"));
 
@@ -13544,6 +13666,8 @@ ${settingsPanelHTML()}
 					);
 				}
 			}
+
+			held.settle();
 		}
 
 		const context = new Map(
@@ -13741,40 +13865,53 @@ ${settingsPanelHTML()}
 	}
 
 	// #region hnewhere-test-export
-	function notesSection(count) {
+	function notesSection() {
 		const section = document.createElement("div");
 		const head = document.createElement("div");
 		const body = document.createElement("div");
+		const foot = document.createElement("div");
 		const toggle = document.createElement("button");
 
-		section.className = "notes-section";
+		section.className = "notepad-section";
 		section.dataset.notesSection = "1";
 
-		head.className = "live-bookend live-bookend-open notes-bookend";
-		head.innerHTML =
-			`<span class="live-bookend-mark">NOTES</span>` +
-			`<span class="live-bookend-text"><span class="notes-bookend-count"></span></span>`;
-		head.querySelector(".notes-bookend-count").textContent = pluralize(
-			count,
-			"note",
-		);
+		head.className = "notepad-rule";
+		head.innerHTML = `<span class="notepad-mark">NOTEPAD</span>`;
 
 		toggle.type = "button";
-		toggle.className = "notes-toggle";
+		toggle.className = "notepad-toggle";
 		toggle.textContent = "hide";
 		toggle.setAttribute("aria-expanded", "true");
 		toggle.onclick = () => {
-			const collapsed = section.classList.toggle("is-collapsed");
+			const collapsed = !section.classList.contains("is-collapsed");
 
+			section.classList.toggle("is-collapsed", collapsed);
+			body.style.maxHeight = collapsed
+				? "0px"
+				: body.scrollHeight
+					? `${body.scrollHeight}px`
+					: "";
 			toggle.textContent = collapsed ? "show" : "hide";
 			toggle.setAttribute("aria-expanded", collapsed ? "false" : "true");
 		};
 
 		head.appendChild(toggle);
-		body.className = "notes-body";
-		section.append(head, body);
+		body.className = "notepad-body";
+		foot.className = "notepad-rule notepad-rule-close";
+		section.append(head, body, foot);
 
-		return { section, body };
+		return {
+			section,
+			body,
+
+			settle() {
+				if (!section.classList.contains("is-collapsed")) {
+					body.style.maxHeight = body.scrollHeight
+						? `${body.scrollHeight}px`
+						: "";
+				}
+			},
+		};
 	}
 	// #endregion hnewhere-test-export
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -3831,6 +3831,39 @@ button {
 	}
 
 	// #region hnewhere-test-export
+	function noteAsText(note) {
+		const quote = String(note?.exact || "").trim();
+		const written = String(note?.text || "").trim();
+
+		return quote ? `> ${quote}\n\n${written}` : written;
+	}
+
+	function editedNote(note, parsed) {
+		const changed = parsed.exact !== String(note.exact || "").trim();
+
+		return {
+			...note,
+			text: parsed.text,
+			exact: parsed.exact,
+			edited: Date.now(),
+			...(changed ? { prefix: "", suffix: "", page: parsed.exact ? note.page : null } : {}),
+		};
+	}
+
+	function noteFromText(value) {
+		const lines = String(value || "").split("\n");
+		const quoted = [];
+
+		while (lines.length && /^\s*>/.test(lines[0])) {
+			quoted.push(lines.shift().replace(/^\s*>\s?/, ""));
+		}
+
+		return {
+			exact: quoted.join(" ").replace(/\s+/g, " ").trim(),
+			text: lines.join("\n").trim(),
+		};
+	}
+
 	function inlineNoteEditor(note, { onSave, onClose }) {
 		const editor = document.createElement("div");
 		const field = document.createElement("textarea");
@@ -3840,7 +3873,7 @@ button {
 
 		editor.className = "note-editor";
 		field.className = "note-editor-field";
-		field.value = note?.text || "";
+		field.value = noteAsText(note);
 		field.setAttribute("aria-label", "Edit your note");
 
 		row.className = "note-editor-row";
@@ -3851,24 +3884,16 @@ button {
 		save.className = "note-editor-save";
 		save.textContent = "save";
 
-		const commit = (dropHighlight = false) => {
-			if (String(field.value || "").trim()) {
-				onSave(field.value, dropHighlight);
+		const commit = () => {
+			const parsed = noteFromText(field.value);
+
+			if (parsed.text || parsed.exact) {
+				onSave(parsed);
 			}
 		};
 
 		cancel.onclick = onClose;
-		save.onclick = () => commit();
-
-		if (note?.exact) {
-			const drop = document.createElement("button");
-
-			drop.type = "button";
-			drop.className = "note-editor-drop";
-			drop.textContent = "remove highlight";
-			drop.onclick = () => commit(true);
-			row.appendChild(drop);
-		}
+		save.onclick = commit;
 		field.onkeydown = (event) => {
 			if (event.key === "Escape") {
 				onClose();
@@ -3886,6 +3911,34 @@ button {
 	}
 	// #endregion hnewhere-test-export
 
+	function settleNotepad(node) {
+		const body = node?.closest?.(".notepad-body");
+		const section = body?.closest(".notepad-section");
+
+		if (!body || section?.classList.contains("is-collapsed")) {
+			return;
+		}
+
+		body.style.maxHeight = body.scrollHeight ? `${body.scrollHeight}px` : "";
+	}
+
+	function openNotepad(section) {
+		const body = section?.querySelector(".notepad-body");
+		const toggle = section?.querySelector(".notepad-toggle");
+
+		if (!section?.classList.contains("is-collapsed")) {
+			return;
+		}
+
+		section.classList.remove("is-collapsed");
+		toggle.textContent = "hide";
+		toggle.setAttribute("aria-expanded", "true");
+
+		if (body) {
+			body.style.maxHeight = body.scrollHeight ? `${body.scrollHeight}px` : "";
+		}
+	}
+
 	function startInlineNoteEdit(div, note) {
 		const text = div.querySelector(".text");
 
@@ -3893,35 +3946,75 @@ button {
 			return;
 		}
 
-		const written = [...text.children].filter(
-			(child) => child.tagName !== "BLOCKQUOTE",
-		);
-
-		for (const child of written) {
-			child.hidden = true;
-		}
-
 		const held = inlineNoteEditor(note, {
-			onSave: (value, dropHighlight) => {
-				updateNote(note.id, value, dropHighlight).catch(console.error);
+			onSave: (parsed) => {
+				updateNote(note.id, parsed).catch(console.error);
 			},
 			onClose: () => {
 				held.editor.remove();
-
-				for (const child of written) {
-					child.hidden = false;
-				}
+				text.hidden = false;
+				settleNotepad(div);
 			},
 		});
 
-		text.appendChild(held.editor);
+		text.hidden = true;
+		text.after(held.editor);
 		held.field.focus();
+		settleNotepad(div);
 	}
 
-	async function updateNote(id, text, dropHighlight = false) {
-		const written = String(text || "").trim();
+	function startNotepadDraft(section, body) {
+		openNotepad(section);
 
-		if (!written) {
+		if (body.querySelector(".note-editor")) {
+			body.querySelector(".note-editor-field")?.focus();
+			return;
+		}
+
+		const held = inlineNoteEditor(null, {
+			onSave: (parsed) => {
+				writeNote(parsed).catch(console.error);
+			},
+			onClose: () => {
+				held.editor.remove();
+				settleNotepad(body.firstElementChild || body);
+			},
+		});
+
+		held.editor.classList.add("note-editor-draft");
+		body.prepend(held.editor);
+		held.field.focus();
+		settleNotepad(held.editor);
+	}
+
+	async function writeNote(parsed) {
+		if (!parsed?.text && !parsed?.exact) {
+			return;
+		}
+
+		const notes = await loadNotes();
+
+		await saveNotes([
+			...notes,
+			{
+				id:
+					"n" +
+					Date.now().toString(36) +
+					Math.floor(Math.random() * 1e6).toString(36),
+				created: Date.now(),
+				text: parsed.text,
+				exact: parsed.exact,
+				prefix: "",
+				suffix: "",
+				page: null,
+				url: location.href,
+			},
+		]);
+		await reopenForNotes();
+	}
+
+	async function updateNote(id, parsed) {
+		if (!parsed?.text && !parsed?.exact) {
 			return;
 		}
 
@@ -3929,16 +4022,7 @@ button {
 
 		await saveNotes(
 			notes.map((note) =>
-				note.id === id
-					? {
-							...note,
-							text: written,
-							edited: Date.now(),
-							...(dropHighlight
-								? { exact: "", prefix: "", suffix: "", page: null }
-								: {}),
-						}
-					: note,
+				note.id === id ? editedNote(note, parsed) : note,
 			),
 		);
 		await reopenForNotes();
@@ -11466,16 +11550,17 @@ ${SUBMIT_FORM_CSS}
 	padding:0;
 	border:0;
 	background:none;
-	color:var(--muted);
+	color:var(--meta);
 	font:inherit;
 	font-size:11px;
-	text-decoration:underline;
+	text-decoration:none;
 	cursor:pointer;
 }
 
 @media (hover: hover) {
-	.notepad-add:hover {
-		color:var(--surface-text);
+	.notepad-add:hover,
+	.notepad-toggle:hover {
+		text-decoration:underline;
 	}
 }
 
@@ -11483,17 +11568,11 @@ ${SUBMIT_FORM_CSS}
 	padding:0;
 	border:0;
 	background:none;
-	color:var(--muted);
+	color:var(--meta);
 	font:inherit;
 	font-size:11px;
-	text-decoration:underline;
+	text-decoration:none;
 	cursor:pointer;
-}
-
-@media (hover: hover) {
-	.notepad-toggle:hover {
-		color:var(--surface-text);
-	}
 }
 
 .notepad-body {
@@ -11505,13 +11584,17 @@ ${SUBMIT_FORM_CSS}
 	opacity:0;
 }
 
+.notepad-section.is-collapsed .notepad-rule-close {
+	display:none;
+}
+
 .note-editor {
 	margin:4px 0 0;
 }
 
 .note-editor-field {
 	width:100%;
-	min-height:56px;
+	min-height:76px;
 	box-sizing:border-box;
 	padding:6px 7px;
 	border:1px solid var(--surface-border);
@@ -11544,9 +11627,7 @@ ${SUBMIT_FORM_CSS}
 	font-weight:600;
 }
 
-.note-editor-drop {
-	margin-right:auto;
-}
+
 
 @media (hover: hover) {
 	.note-editor-row button:hover {
@@ -13703,19 +13784,7 @@ ${settingsPanelHTML()}
 
 		if (localStories.length || notesOn) {
 			const held = notesSection({
-				onAdd: (button) => {
-					const rect = button.getBoundingClientRect();
-
-					openNoteComposer({
-						exact: "",
-						prefix: "",
-						suffix: "",
-						page: null,
-						anchorable: false,
-						left: Math.max(8, rect.left - 300),
-						top: rect.bottom,
-					}).catch(console.error);
-				},
+				onAdd: () => startNotepadDraft(held.section, held.body),
 			});
 
 			ui.body.insertBefore(held.section, ui.body.querySelector(".page-sort"));
@@ -17632,6 +17701,7 @@ title="Show only this discussion">
 
 				group.comments.push({
 					commentId: rendered.id,
+					source: rendered.source,
 					element: rendered.element,
 					textElement: rendered.textElement,
 					author: rendered.author,
@@ -18467,6 +18537,10 @@ title="Show only this discussion">
 	function decorateSidebarMatches(controller) {
 		for (const group of controller.groups) {
 			for (const comment of group.comments) {
+				if (getSource(comment.source)?.local) {
+					continue;
+				}
+
 				const onActivate = () => {
 					applyCommentFilter(group.key, {
 						commentId: comment.commentId,

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Backchannel
 // @namespace    https://github.com/twalichiewicz/HNewhere
-// @version      1.6.7
+// @version      1.6.8
 // @license      MIT
 // @updateURL    https://raw.githubusercontent.com/twalichiewicz/Backchannel/main/HNewhere.user.js
 // @downloadURL  https://raw.githubusercontent.com/twalichiewicz/Backchannel/main/HNewhere.user.js
@@ -42,7 +42,10 @@
 // @grant        GM.getValue
 // @grant        GM.setValue
 // @grant        GM.xmlHttpRequest
+// @grant        GM.getResourceText
 // @grant        unsafeWindow
+// @resource     pdfjsCore   https://cdn.jsdelivr.net/npm/pdfjs-dist@6.2.108/build/pdf.min.mjs
+// @resource     pdfjsWorker https://cdn.jsdelivr.net/npm/pdfjs-dist@6.2.108/build/pdf.worker.min.mjs
 // @connect      hacker-news.firebaseio.com
 // @connect      hn.algolia.com
 // @connect      news.ycombinator.com
@@ -343,6 +346,7 @@
 	const DEFAULT_SETTINGS = {
 		annotations: false,
 		annotationsWhenSidebarClosed: false,
+		pdfReader: false,
 		autoOpenSidebar: false,
 		autoOpenSidebarOnlyFromHN: false,
 		hideWithoutDiscussion: false,
@@ -9773,6 +9777,15 @@ Highlights the passages commenters quote, so you can jump between the article an
 <input id="setting-annotations-closed" data-setting="annotationsWhenSidebarClosed" type="checkbox">
 <span>Show when sidebar closed</span>
 </label>
+<label class="settings-option sub-option">
+<input id="setting-pdf-reader" data-setting="pdfReader" type="checkbox">
+<span>Read PDFs here, so passages can be highlighted</span>
+</label>
+<div class="settings-option-hint">
+Chrome and Safari keep a PDF's text out of the page, so nothing can be
+highlighted in one. With this on, a PDF offers to open in a reader that can —
+and closing it puts your browser's viewer back.
+</div>
 </div>
 </div>
 
@@ -9925,6 +9938,7 @@ ${[
 			annotationsWhenSidebarClosed: shadow.querySelector(
 				"#setting-annotations-closed",
 			),
+			pdfReader: shadow.querySelector("#setting-pdf-reader"),
 			autoOpenSidebarOnlyFromHN: shadow.querySelector(
 				"#setting-auto-open-only-from-hn",
 			),
@@ -15215,7 +15229,10 @@ title="Show only this discussion">
 			}
 
 			if (node.tagName === "BR") {
-				pushSeparator("\n");
+				if (!options.weldBreaks) {
+					pushSeparator("\n");
+				}
+
 				return;
 			}
 
@@ -15369,7 +15386,477 @@ title="Show only this discussion">
 		return { pageIndex: low, offsetInPage: offset - pageStarts[low] };
 	}
 
+	// -------------------------
+	// Our own PDF reader
+	// -------------------------
+
+	const PDFJS_VERSION = "6.2.108";
+	const PDFJS_BASE = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/build/`;
+
+	const PDF_READER_CSS = `
+.hnewhere-pdf-viewer { --scale-factor: 1; --total-scale-factor: 1; --scale-round-x: 1px; --scale-round-y: 1px; }
+.hnewhere-pdf-viewer .page { position: relative; margin: 0 auto 12px; background: #fff; box-shadow: 0 1px 4px rgba(0,0,0,.3); }
+.hnewhere-pdf-viewer .canvasWrapper { position: absolute; inset: 0; overflow: hidden; }
+.hnewhere-pdf-viewer .canvasWrapper canvas { display: block; }
+.hnewhere-pdf-viewer .textLayer {
+	position: absolute; text-align: initial; inset: 0; overflow: clip; opacity: 1;
+	line-height: 1; letter-spacing: normal; word-spacing: normal;
+	-webkit-text-size-adjust: none; text-size-adjust: none;
+	forced-color-adjust: none; transform-origin: 0 0; z-index: 0;
+	--min-font-size: 1;
+	--text-scale-factor: calc(var(--total-scale-factor) * var(--min-font-size));
+	--min-font-size-inv: calc(1 / var(--min-font-size));
+}
+.hnewhere-pdf-viewer .textLayer :is(span, br) {
+	color: transparent; position: absolute; white-space: pre; cursor: text;
+	transform-origin: 0% 0%;
+}
+.hnewhere-pdf-viewer .textLayer > :not(.markedContent),
+.hnewhere-pdf-viewer .textLayer .markedContent span:not(.markedContent) {
+	z-index: 1;
+	--font-height: 0;
+	font-size: calc(var(--text-scale-factor) * var(--font-height));
+	--scale-x: 1;
+	--rotate: 0deg;
+	transform: rotate(var(--rotate)) scaleX(var(--scale-x)) scale(var(--min-font-size-inv));
+}
+.hnewhere-pdf-viewer .textLayer .markedContent { display: contents; }
+`;
+
+	let pdfjsModule = null;
+	let ownPdfReader = null;
+
+	function looksLikePdfDocument() {
+		return (
+			document.contentType === "application/pdf" ||
+			/\.pdf(?:[?#]|$)/i.test(location.pathname + location.search)
+		);
+	}
+
+	async function pdfjsResourceText(name, url) {
+		try {
+			const text = await GM?.getResourceText?.(name);
+
+			if (text) {
+				return text;
+			}
+		} catch {
+			/* empty */
+		}
+
+		return (await fetch(url, { cache: "force-cache" })).text();
+	}
+
+	async function loadPdfjs() {
+		if (pdfjsModule) {
+			return pdfjsModule;
+		}
+
+		const [core, worker] = await Promise.all([
+			pdfjsResourceText("pdfjsCore", PDFJS_BASE + "pdf.min.mjs"),
+			pdfjsResourceText("pdfjsWorker", PDFJS_BASE + "pdf.worker.min.mjs"),
+		]);
+
+		const asURL = (text) =>
+			URL.createObjectURL(new Blob([text], { type: "text/javascript" }));
+		const module_ = await import(asURL(core));
+
+		module_.GlobalWorkerOptions.workerSrc = asURL(worker);
+		pdfjsModule = module_;
+
+		return module_;
+	}
+
+	function pdfReaderBus() {
+		const listeners = new Map();
+
+		return {
+			on(name, callback) {
+				if (!listeners.has(name)) {
+					listeners.set(name, new Set());
+				}
+
+				listeners.get(name).add(callback);
+			},
+
+			off(name, callback) {
+				listeners.get(name)?.delete(callback);
+			},
+
+			dispatch(name, payload) {
+				for (const callback of [...(listeners.get(name) || [])]) {
+					try {
+						callback(payload);
+					} catch (e) {
+						console.error("Backchannel pdf reader listener failed:", e);
+					}
+				}
+			},
+		};
+	}
+
+	function pdfReaderButton(label, onClick) {
+		const button = document.createElement("button");
+
+		button.type = "button";
+		button.textContent = label;
+		pinButtonStyle(button, {
+			...BUTTON_STYLE_RESET,
+			display: "inline-block",
+			padding: "8px 14px",
+			borderRadius: "8px",
+			background: "#237140",
+			color: "#fff",
+			fontFamily: "system-ui, -apple-system, Segoe UI, sans-serif",
+			fontSize: "13px",
+			fontWeight: "600",
+			cursor: "pointer",
+			boxShadow: "0 2px 8px rgba(0,0,0,.35)",
+			pointerEvents: "auto",
+		});
+		button.addEventListener("click", onClick);
+
+		return button;
+	}
+
+	function buildPdfReaderChrome() {
+		const host = document.createElement("div");
+
+		host.setAttribute("data-hnewhere-pdf-reader", "1");
+		host.style.cssText = `
+			position:fixed;
+			inset:0;
+			z-index:2147483644;
+			background:#3a3a3a;
+			overflow:auto;
+			overscroll-behavior:contain;
+		`;
+
+		const style = document.createElement("style");
+		style.textContent = PDF_READER_CSS;
+
+		const viewer = document.createElement("div");
+		viewer.className = "hnewhere-pdf-viewer pdfViewer";
+		viewer.style.cssText = "position:relative;padding:12px 0;";
+
+		const bar = document.createElement("div");
+		bar.style.cssText = `
+			position:fixed;
+			right:16px;
+			bottom:16px;
+			z-index:1;
+			display:flex;
+			gap:8px;
+			align-items:center;
+		`;
+
+		const counter = document.createElement("span");
+		counter.setAttribute("data-hnewhere-pdf-counter", "1");
+		counter.style.cssText = `
+			padding:8px 12px;
+			border-radius:8px;
+			background:rgba(0,0,0,.55);
+			color:#fff;
+			font:600 13px/1 system-ui, -apple-system, sans-serif;
+			white-space:nowrap;
+		`;
+
+		bar.append(
+			counter,
+			pdfReaderButton("−", () => {
+				setPdfReaderScale((ownPdfReader?.scale || 1) / 1.25).catch(console.error);
+			}),
+			pdfReaderButton("+", () => {
+				setPdfReaderScale((ownPdfReader?.scale || 1) * 1.25).catch(console.error);
+			}),
+			pdfReaderButton("Close reader", () => {
+				closePdfReader();
+				refreshArticleAnnotations().catch(console.error);
+			}),
+		);
+
+		host.append(style, viewer, bar);
+
+		return host;
+	}
+
+	function syncPdfReaderCounter() {
+		const reader = ownPdfReader;
+		const counter = reader?.host.querySelector("[data-hnewhere-pdf-counter]");
+
+		if (!counter) {
+			return;
+		}
+
+		const top = reader.host.getBoundingClientRect().top;
+		let current = 1;
+
+		for (const box of reader.pages) {
+			if (box.getBoundingClientRect().bottom > top + 8) {
+				current = Number(box.dataset.pageNumber);
+				break;
+			}
+		}
+
+		counter.textContent = `${current} / ${reader.pages.length}`;
+	}
+
+	async function drawPdfReaderVisiblePages() {
+		const reader = ownPdfReader;
+
+		if (!reader) {
+			return;
+		}
+
+		const view = reader.host.getBoundingClientRect();
+
+		for (const box of reader.pages) {
+			const rect = box.getBoundingClientRect();
+
+			if (rect.bottom > view.top - 400 && rect.top < view.bottom + 400) {
+				await drawPdfReaderPage(Number(box.dataset.pageNumber));
+			}
+		}
+	}
+
+	async function setPdfReaderScale(scale) {
+		const reader = ownPdfReader;
+		const next = Math.max(0.25, Math.min(4, scale));
+
+		if (!reader || Math.abs(next - reader.scale) < 0.001) {
+			return;
+		}
+
+		const held = reader.viewer.scrollHeight
+			? reader.host.scrollTop / reader.viewer.scrollHeight
+			: 0;
+		const sized = (await reader.app.pdfDocument.getPage(1)).getViewport({
+			scale: next,
+		});
+
+		if (ownPdfReader !== reader) {
+			return;
+		}
+
+		reader.scale = next;
+		reader.viewer.style.setProperty("--scale-factor", String(next));
+		reader.viewer.style.setProperty("--total-scale-factor", String(next));
+		reader.drawn.clear();
+
+		for (const box of reader.pages) {
+			box.textContent = "";
+			box.style.width = Math.floor(sized.width) + "px";
+			box.style.height = Math.floor(sized.height) + "px";
+		}
+
+		reader.host.scrollTop = held * reader.viewer.scrollHeight;
+		reader.bus.dispatch("scalechanging", { scale: next, source: reader.app });
+
+		await drawPdfReaderVisiblePages();
+		syncPdfReaderCounter();
+	}
+
+	function removePdfReaderOffer() {
+		document.querySelector("[data-hnewhere-pdf-offer]")?.remove();
+	}
+
+	function syncPdfReaderOffer(settings) {
+		removePdfReaderOffer();
+
+		if (
+			!settings?.annotations ||
+			!settings.pdfReader ||
+			ownPdfReader ||
+			!looksLikePdfDocument() ||
+			document.querySelector(".pdfViewer .textLayer")
+		) {
+			return;
+		}
+
+		const offer = document.createElement("div");
+
+		offer.setAttribute("data-hnewhere-pdf-offer", "1");
+		offer.style.cssText = `
+			position:fixed;
+			left:50%;
+			bottom:24px;
+			transform:translateX(-50%);
+			z-index:2147483643;
+		`;
+		offer.appendChild(
+			pdfReaderButton("Open this PDF where passages can be highlighted", () => {
+				removePdfReaderOffer();
+				openPdfReader()
+					.then(() => refreshArticleAnnotations())
+					.catch((e) => {
+						console.error("Backchannel could not open the PDF reader:", e);
+						closePdfReader();
+					});
+			}),
+		);
+
+		document.documentElement.appendChild(offer);
+	}
+
+	async function drawPdfReaderPage(number) {
+		const reader = ownPdfReader;
+
+		if (!reader || reader.drawn.has(number)) {
+			return;
+		}
+
+		reader.drawn.add(number);
+
+		const box = reader.pages[number - 1];
+		const page = await reader.app.pdfDocument.getPage(number);
+
+		if (ownPdfReader !== reader || !box) {
+			return;
+		}
+
+		const viewport = page.getViewport({ scale: reader.scale });
+
+		box.style.width = Math.floor(viewport.width) + "px";
+		box.style.height = Math.floor(viewport.height) + "px";
+
+		const canvas = document.createElement("canvas");
+		canvas.width = Math.floor(viewport.width);
+		canvas.height = Math.floor(viewport.height);
+
+		const wrapper = document.createElement("div");
+		wrapper.className = "canvasWrapper";
+		wrapper.appendChild(canvas);
+		box.appendChild(wrapper);
+
+		await page.render({ canvasContext: canvas.getContext("2d"), viewport }).promise;
+
+		if (ownPdfReader !== reader) {
+			return;
+		}
+
+		const layer = document.createElement("div");
+		layer.className = "textLayer";
+		box.appendChild(layer);
+
+		await new reader.pdfjs.TextLayer({
+			textContentSource: page.streamTextContent(),
+			container: layer,
+			viewport,
+		}).render();
+
+		if (ownPdfReader !== reader) {
+			return;
+		}
+
+		reader.bus.dispatch("textlayerrendered", {
+			pageNumber: number,
+			source: reader.app,
+		});
+	}
+
+	function observePdfReaderPages() {
+		const reader = ownPdfReader;
+
+		if (!reader) {
+			return;
+		}
+
+		reader.observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						drawPdfReaderPage(Number(entry.target.dataset.pageNumber)).catch(
+							console.error,
+						);
+					}
+				}
+			},
+			{ root: reader.host, rootMargin: "400px 0px" },
+		);
+
+		for (const box of reader.pages) {
+			reader.observer.observe(box);
+		}
+	}
+
+	async function openPdfReader() {
+		if (ownPdfReader) {
+			return ownPdfReader;
+		}
+
+		const pdfjs = await loadPdfjs();
+		const response = await fetch(location.href, { cache: "force-cache" });
+		const bytes = new Uint8Array(await response.arrayBuffer());
+		const pdfDocument = await pdfjs.getDocument({ data: bytes }).promise;
+		const host = buildPdfReaderChrome();
+		const viewer = host.querySelector(".pdfViewer");
+
+		document.documentElement.appendChild(host);
+
+		const base = (await pdfDocument.getPage(1)).getViewport({ scale: 1 });
+		const scale = Math.max(
+			0.2,
+			Math.min(3, (host.clientWidth - 32) / base.width || 1),
+		);
+		const sized = (await pdfDocument.getPage(1)).getViewport({ scale });
+		const pages = [];
+
+		for (let number = 1; number <= pdfDocument.numPages; number += 1) {
+			const box = document.createElement("div");
+
+			box.className = "page";
+			box.dataset.pageNumber = String(number);
+			box.style.width = Math.floor(sized.width) + "px";
+			box.style.height = Math.floor(sized.height) + "px";
+			viewer.appendChild(box);
+			pages.push(box);
+		}
+
+		viewer.style.setProperty("--scale-factor", String(scale));
+		viewer.style.setProperty("--total-scale-factor", String(scale));
+
+		const bus = pdfReaderBus();
+
+		ownPdfReader = {
+			app: { pdfDocument, eventBus: bus },
+			bus,
+			host,
+			viewer,
+			pages,
+			pdfjs,
+			scale,
+			drawn: new Set(),
+			observer: null,
+		};
+
+		observePdfReaderPages();
+		syncPdfReaderCounter();
+
+		host.addEventListener("scroll", syncPdfReaderCounter, { passive: true });
+		bus.dispatch("pagesloaded", { source: ownPdfReader.app });
+
+		return ownPdfReader;
+	}
+
+	function closePdfReader() {
+		const reader = ownPdfReader;
+
+		if (!reader) {
+			return;
+		}
+
+		reader.observer?.disconnect();
+		reader.host.remove();
+		ownPdfReader = null;
+		pdfTexts = null;
+		pdfTextsFor = null;
+	}
+
 	function pdfViewerApp() {
+		if (ownPdfReader?.app?.pdfDocument) {
+			return ownPdfReader.app;
+		}
+
 		const scopes = [
 			typeof unsafeWindow !== "undefined" ? unsafeWindow : null,
 			typeof window !== "undefined" ? window : null,
@@ -15405,6 +15892,7 @@ title="Show only this discussion">
 
 		const index = buildTextIndex(layer, {
 			skipHidden: true,
+			weldBreaks: true,
 			excludeSelectors: [
 				"[data-hnewhere-annotation-overlay]",
 				"[data-hnewhere-sidebar]",
@@ -15480,6 +15968,10 @@ title="Show only this discussion">
 				const pageIndex = at && pdfPageIndex(at.pageIndex);
 
 				if (!pageIndex) {
+					if (at && ownPdfReader) {
+						drawPdfReaderPage(at.pageIndex + 1).catch(console.error);
+					}
+
 					return null;
 				}
 
@@ -15533,7 +16025,8 @@ title="Show only this discussion">
 		},
 
 		scrollIntoView(range) {
-			const container = document.getElementById("viewerContainer");
+			const container =
+				ownPdfReader?.host || document.getElementById("viewerContainer");
 
 			if (!container) {
 				HTML_DOCUMENT_SOURCE.scrollIntoView(range);
@@ -15757,18 +16250,28 @@ title="Show only this discussion">
 		};
 	}
 
-	function findBestQuoteMatch(articleIndex, candidate) {
-		const quoteText = typeof candidate === "string" ? candidate : candidate.text;
-		let best = null;
+	function exactSearchTexts(text) {
+		const whole = String(text || "");
+		const withoutNumber = whole.replace(/^\s*\d+\.\s*/, "");
 
-		if (typeof candidate === "object" && candidate.exact) {
-			const normalized = normalizeSearchText(quoteText).text;
-			const matches = findNormalizedOccurrences(
-				articleIndex.normalizedText,
-				normalized,
-			);
-			let at = null;
-			let context = null;
+		return withoutNumber && withoutNumber !== whole
+			? [whole, withoutNumber]
+			: [whole];
+	}
+
+	function matchExactQuote(articleIndex, candidate, text, quoteText) {
+		const normalized = normalizeSearchText(text).text;
+
+		if (!normalized) {
+			return null;
+		}
+
+		const matches = findNormalizedOccurrences(
+			articleIndex.normalizedText,
+			normalized,
+		);
+		let at = null;
+		let context = null;
 
 			if (matches.length === 1) {
 				at = matches[0];
@@ -15802,25 +16305,39 @@ title="Show only this discussion">
 				}
 			}
 
-			if (at !== null) {
-				const rangeMatch = rangeFromIndexMatch(
-					articleIndex,
-					at,
-					normalized.length,
-				);
+		if (at === null) {
+			return null;
+		}
 
-				if (rangeMatch && getPageRectsForRange(rangeMatch.range).length) {
-					return {
-						score: normalized.length * 10 + 10000,
-						key: `${rangeMatch.startRaw}:${rangeMatch.endRaw}`,
-						range: rangeMatch.range,
-						quoteText,
-						fullQuoteText: quoteText,
-						quoteNormalized: normalized,
-						startRaw: rangeMatch.startRaw,
-						endRaw: rangeMatch.endRaw,
-						contextMatched: context?.matched ?? null,
-					};
+		const rangeMatch = rangeFromIndexMatch(articleIndex, at, normalized.length);
+
+		if (!rangeMatch || !getPageRectsForRange(rangeMatch.range).length) {
+			return null;
+		}
+
+		return {
+			score: normalized.length * 10 + 10000,
+			key: `${rangeMatch.startRaw}:${rangeMatch.endRaw}`,
+			range: rangeMatch.range,
+			quoteText,
+			fullQuoteText: quoteText,
+			quoteNormalized: normalized,
+			startRaw: rangeMatch.startRaw,
+			endRaw: rangeMatch.endRaw,
+			contextMatched: context?.matched ?? null,
+		};
+	}
+
+	function findBestQuoteMatch(articleIndex, candidate) {
+		const quoteText = typeof candidate === "string" ? candidate : candidate.text;
+		let best = null;
+
+		if (typeof candidate === "object" && candidate.exact) {
+			for (const text of exactSearchTexts(quoteText)) {
+				const match = matchExactQuote(articleIndex, candidate, text, quoteText);
+
+				if (match) {
+					return match;
 				}
 			}
 		}
@@ -17125,6 +17642,7 @@ title="Show only this discussion">
 
 	async function refreshArticleAnnotations() {
 		clearArticleAnnotations();
+		syncPdfReaderOffer(await loadSettings());
 
 		if (!sidebar || !renderedComments.length) {
 			return;

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -4962,6 +4962,7 @@ ${
 	// #region hnewhere-test-export
 	function pageTitle(doc = document) {
 		const candidates = [
+			doc === document ? pdfTitle : null,
 			doc.querySelector('meta[property="og:title"]')?.content,
 			doc.querySelector('meta[name="twitter:title"]')?.content,
 			doc.title,
@@ -16015,6 +16016,8 @@ title="Show only this discussion">
 		ownPdfReader = null;
 		pdfTexts = null;
 		pdfTextsFor = null;
+		pdfTitle = null;
+		pdfTitleFor = null;
 	}
 
 	function pdfViewerApp() {
@@ -16082,6 +16085,76 @@ title="Show only this discussion">
 			} catch (e) {
 				console.error("Backchannel pdf reindex failed:", e);
 			}
+		}
+	}
+
+	let pdfTitle = null;
+	let pdfTitleFor = null;
+
+	function plausiblePdfTitle(value) {
+		const title = String(value || "")
+			.replace(/\s+/g, " ")
+			.replace(/^Microsoft Word\s*-\s*/i, "")
+			.trim();
+
+		if (title.length < 4 || title.length > 200) {
+			return null;
+		}
+
+		if (/^untitled/i.test(title) || /\.(pdf|tex|dvi|docx?|indd|qxd)$/i.test(title)) {
+			return null;
+		}
+
+		return title;
+	}
+
+	async function pdfHeadingTitle(document_) {
+		const upright = (await pdfPageTextItems(await document_.getPage(1))).filter(
+			(item) => {
+				const transform = item.transform || [1, 0, 0, 1, 0, 0];
+
+				return (
+					item.str.trim() &&
+					Math.abs(transform[1]) < 0.01 &&
+					Math.abs(transform[2]) < 0.01
+				);
+			},
+		);
+
+		if (!upright.length) {
+			return null;
+		}
+
+		const tallest = Math.max(
+			...upright.map((item) => Math.round(item.height * 10)),
+		);
+
+		return plausiblePdfTitle(
+			upright
+				.filter((item) => Math.round(item.height * 10) === tallest)
+				.map((item) => item.str)
+				.join(""),
+		);
+	}
+
+	async function loadPdfTitle(app) {
+		const document_ = app?.pdfDocument;
+
+		if (!document_ || pdfTitleFor === document_) {
+			return;
+		}
+
+		pdfTitleFor = document_;
+
+		try {
+			const meta = await document_.getMetadata();
+
+			pdfTitle =
+				plausiblePdfTitle(meta?.info?.Title) ||
+				plausiblePdfTitle(meta?.metadata?.get?.("dc:title")) ||
+				(await pdfHeadingTitle(document_));
+		} catch (error) {
+			console.error("Backchannel could not read the PDF title:", error);
 		}
 	}
 
@@ -18093,6 +18166,7 @@ title="Show only this discussion">
 		markQueueArrival().catch(console.error);
 
 		await ensurePdfReader(settings);
+		await loadPdfTitle(pdfViewerApp());
 
 		const votesReady = Promise.all([
 			loadRememberedVotes(),

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -4387,6 +4387,92 @@ button {
 		await save(NOTES_INDEX_KEY, entries);
 	}
 
+	// #region hnewhere-test-export
+	function notedDocuments(index) {
+		return (Array.isArray(index) ? index : []).filter(
+			(entry) => entry?.kind && entry?.id,
+		);
+	}
+
+	function notesExportName(now) {
+		const pad = (value) => String(value).padStart(2, "0");
+
+		return (
+			"backchannel-notes-" +
+			now.getFullYear() +
+			"-" +
+			pad(now.getMonth() + 1) +
+			"-" +
+			pad(now.getDate()) +
+			".json"
+		);
+	}
+
+	function notesExportPayload(documents, exported) {
+		const kept = documents.filter((entry) => entry.notes.length);
+
+		return {
+			application: "Backchannel",
+			version: 1,
+			exported,
+			documentCount: kept.length,
+			noteCount: kept.reduce((total, entry) => total + entry.notes.length, 0),
+			documents: kept,
+		};
+	}
+	// #endregion hnewhere-test-export
+
+	async function collectNotes() {
+		const index = notedDocuments(await load(NOTES_INDEX_KEY, []));
+		const documents = [];
+
+		for (const entry of index) {
+			const ref = { kind: entry.kind, id: entry.id };
+
+			documents.push({
+				kind: ref.kind,
+				id: ref.id,
+				url: entry.url || null,
+				title: entry.title || null,
+				updated: entry.updated || null,
+				notes: keptNotes(await load(entry.key || noteStorageKey(ref), null)),
+			});
+		}
+
+		return documents;
+	}
+
+	function downloadJSON(payload, name) {
+		const href = URL.createObjectURL(
+			new Blob([JSON.stringify(payload, null, 2)], {
+				type: "application/json",
+			}),
+		);
+		const link = document.createElement("a");
+
+		link.href = href;
+		link.download = name;
+		link.style.display = "none";
+		document.body.appendChild(link);
+		link.click();
+		link.remove();
+
+		window.setTimeout(() => URL.revokeObjectURL(href), 10000);
+	}
+
+	async function exportNotes() {
+		const now = new Date();
+		const payload = notesExportPayload(await collectNotes(), now.toISOString());
+
+		if (!payload.noteCount) {
+			return payload;
+		}
+
+		downloadJSON(payload, notesExportName(now));
+
+		return payload;
+	}
+
 	const MASTODON_INSTANCE = "https://mastodon.social";
 	const TOOTFINDER = "https://www.tootfinder.ch";
 
@@ -9684,12 +9770,53 @@ header button svg {
 	margin-top:8px;
 }
 
-.settings-suboptions + .settings-option {
+.settings-suboptions + .settings-option,
+.settings-suboptions + .settings-option-row {
 	margin-top:8px;
 }
 
-.settings-option-hint + .settings-option {
+.settings-option-hint + .settings-option,
+.settings-option-hint + .settings-option-row {
 	margin-top:8px;
+}
+
+.settings-option-row {
+	display:flex;
+	align-items:flex-start;
+	gap:8px;
+}
+
+.settings-option-row > .settings-option {
+	flex:1 1 auto;
+}
+
+.settings-inline-action {
+	flex:0 0 auto;
+	max-width:0;
+	padding:0;
+	border:0;
+	overflow:hidden;
+	background:none;
+	color:var(--muted);
+	font:inherit;
+	font-size:11px;
+	line-height:1.35;
+	white-space:nowrap;
+	text-decoration:none;
+	opacity:0;
+	cursor:pointer;
+	transition:max-width .25s ease, opacity .2s ease;
+}
+
+.settings-option-row.is-checked .settings-inline-action {
+	max-width:120px;
+	opacity:1;
+}
+
+@media (hover: hover) {
+	.settings-inline-action:hover {
+		text-decoration:underline;
+	}
 }
 
 .settings-credits {
@@ -10715,13 +10842,16 @@ The default PDF reader will be replaced with
 allowing highlighting and annotation directly onto the PDF.
 </div>
 </div>
+<div class="settings-option-row">
 <label class="settings-option">
 <input id="setting-notepad" data-setting="notepad" type="checkbox">
 <span>Enable notepad</span>
 </label>
+<button id="settings-notes-export" class="settings-inline-action" type="button">export</button>
+</div>
 <div class="settings-option-hint">
-Write your own notes on any article or PDF, with support for annotating a
-passage you select. Stored locally.
+Write your own notes on any article or PDF, with support for annotation.
+All stored locally.
 </div>
 </div>
 
@@ -11114,6 +11244,35 @@ ${[
 
 				setHideMenuOpen(false);
 			});
+		}
+
+		const notesExport = shadow.querySelector("#settings-notes-export");
+
+		if (notesExport) {
+			notesExport.onclick = (event) => {
+				event.preventDefault();
+				event.stopPropagation();
+
+				const restore = notesExport.textContent;
+
+				notesExport
+					.animate?.(
+						[{ opacity: 1 }, { opacity: 0.35 }, { opacity: 1 }],
+						{ duration: 420 },
+					);
+
+				exportNotes()
+					.then((payload) => {
+						notesExport.textContent = payload.noteCount
+							? "exported"
+							: "no notes yet";
+
+						window.setTimeout(() => {
+							notesExport.textContent = restore;
+						}, 1800);
+					})
+					.catch(console.error);
+			};
 		}
 
 		settingsPanel.addEventListener("click", (event) => {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -3851,14 +3851,24 @@ button {
 		save.className = "note-editor-save";
 		save.textContent = "save";
 
-		const commit = () => {
+		const commit = (dropHighlight = false) => {
 			if (String(field.value || "").trim()) {
-				onSave(field.value);
+				onSave(field.value, dropHighlight);
 			}
 		};
 
 		cancel.onclick = onClose;
-		save.onclick = commit;
+		save.onclick = () => commit();
+
+		if (note?.exact) {
+			const drop = document.createElement("button");
+
+			drop.type = "button";
+			drop.className = "note-editor-drop";
+			drop.textContent = "remove highlight";
+			drop.onclick = () => commit(true);
+			row.appendChild(drop);
+		}
 		field.onkeydown = (event) => {
 			if (event.key === "Escape") {
 				onClose();
@@ -3883,22 +3893,32 @@ button {
 			return;
 		}
 
+		const written = [...text.children].filter(
+			(child) => child.tagName !== "BLOCKQUOTE",
+		);
+
+		for (const child of written) {
+			child.hidden = true;
+		}
+
 		const held = inlineNoteEditor(note, {
-			onSave: (value) => {
-				updateNote(note.id, value).catch(console.error);
+			onSave: (value, dropHighlight) => {
+				updateNote(note.id, value, dropHighlight).catch(console.error);
 			},
 			onClose: () => {
 				held.editor.remove();
-				text.hidden = false;
+
+				for (const child of written) {
+					child.hidden = false;
+				}
 			},
 		});
 
-		text.hidden = true;
-		text.after(held.editor);
+		text.appendChild(held.editor);
 		held.field.focus();
 	}
 
-	async function updateNote(id, text) {
+	async function updateNote(id, text, dropHighlight = false) {
 		const written = String(text || "").trim();
 
 		if (!written) {
@@ -3909,7 +3929,16 @@ button {
 
 		await saveNotes(
 			notes.map((note) =>
-				note.id === id ? { ...note, text: written, edited: Date.now() } : note,
+				note.id === id
+					? {
+							...note,
+							text: written,
+							edited: Date.now(),
+							...(dropHighlight
+								? { exact: "", prefix: "", suffix: "", page: null }
+								: {}),
+						}
+					: note,
 			),
 		);
 		await reopenForNotes();
@@ -11432,8 +11461,25 @@ ${SUBMIT_FORM_CSS}
 	background:var(--hover-tint);
 }
 
-.notepad-toggle {
+.notepad-add {
 	margin-left:auto;
+	padding:0;
+	border:0;
+	background:none;
+	color:var(--muted);
+	font:inherit;
+	font-size:11px;
+	text-decoration:underline;
+	cursor:pointer;
+}
+
+@media (hover: hover) {
+	.notepad-add:hover {
+		color:var(--surface-text);
+	}
+}
+
+.notepad-toggle {
 	padding:0;
 	border:0;
 	background:none;
@@ -11496,6 +11542,10 @@ ${SUBMIT_FORM_CSS}
 
 .note-editor-save {
 	font-weight:600;
+}
+
+.note-editor-drop {
+	margin-right:auto;
 }
 
 @media (hover: hover) {
@@ -13231,7 +13281,10 @@ ${settingsPanelHTML()}
 		${comment.isOP ? `<span class="op-pill">OP</span>` : ""}
 
 		${
-				parentKey === null && discussion.label && sidebarSourceKeys.size > 1
+				parentKey === null &&
+					!isLocalSource &&
+					discussion.label &&
+					sidebarSourceKeys.size > 1
 					? `<span class="comment-source">${escapeHTML(
 							liveDiscussions.has(discussion.key)
 								? discussion.baseLabel || discussion.label
@@ -13396,10 +13449,12 @@ ${settingsPanelHTML()}
 			};
 		}
 
-		focusButton.onclick = function (event) {
-			event.preventDefault();
-			applyCommentFocus(comment.key);
-		};
+		if (focusButton) {
+			focusButton.onclick = function (event) {
+				event.preventDefault();
+				applyCommentFocus(comment.key);
+			};
+		}
 
 		if (replies.length) {
 			await renderChildren(
@@ -13642,8 +13697,26 @@ ${settingsPanelHTML()}
 			),
 		);
 
-		if (localStories.length) {
-			const held = notesSection();
+		const notesOn = enabledSourceIds(settings, registeredSourceIds()).includes(
+			"notes",
+		);
+
+		if (localStories.length || notesOn) {
+			const held = notesSection({
+				onAdd: (button) => {
+					const rect = button.getBoundingClientRect();
+
+					openNoteComposer({
+						exact: "",
+						prefix: "",
+						suffix: "",
+						page: null,
+						anchorable: false,
+						left: Math.max(8, rect.left - 300),
+						top: rect.bottom,
+					}).catch(console.error);
+				},
+			});
 
 			ui.body.insertBefore(held.section, ui.body.querySelector(".page-sort"));
 
@@ -13865,12 +13938,13 @@ ${settingsPanelHTML()}
 	}
 
 	// #region hnewhere-test-export
-	function notesSection() {
+	function notesSection({ onAdd } = {}) {
 		const section = document.createElement("div");
 		const head = document.createElement("div");
 		const body = document.createElement("div");
 		const foot = document.createElement("div");
 		const toggle = document.createElement("button");
+		const add = document.createElement("button");
 
 		section.className = "notepad-section";
 		section.dataset.notesSection = "1";
@@ -13895,7 +13969,12 @@ ${settingsPanelHTML()}
 			toggle.setAttribute("aria-expanded", collapsed ? "false" : "true");
 		};
 
-		head.appendChild(toggle);
+		add.type = "button";
+		add.className = "notepad-add";
+		add.textContent = "add a note";
+		add.onclick = () => onAdd?.(add);
+
+		head.append(add, toggle);
 		body.className = "notepad-body";
 		foot.className = "notepad-rule notepad-rule-close";
 		section.append(head, body, foot);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -2825,6 +2825,10 @@ ${
 	// #region hnewhere-test-export
 	const HINTED_SETTINGS = new Set(["annotations", "pdfReader", "notepad"]);
 
+	function pdfViewerRefusesExtensions() {
+		return /firefox/i.test(navigator.userAgent || "");
+	}
+
 	function syncOptionHint(input) {
 		const anchor =
 			input?.closest?.(".settings-option-row") ||
@@ -9777,6 +9781,11 @@ header button svg {
 	font-size:11px;
 }
 
+.settings-option[hidden],
+.settings-option-hint[hidden] {
+	display:none;
+}
+
 .settings-suboptions {
 	overflow:hidden;
 	max-height:0;
@@ -9786,7 +9795,7 @@ header button svg {
 }
 
 .settings-suboptions.is-visible {
-	max-height:140px;
+	max-height:260px;
 	opacity:1;
 	margin-top:8px;
 }
@@ -10178,6 +10187,17 @@ header button svg {
 
 .settings-option-hint-slow {
 	margin:6px 0 0;
+}
+
+.settings-notice {
+	margin:0 0 12px;
+	padding:6px 8px;
+	border:1px solid var(--help-border);
+	border-radius:4px;
+	background:var(--help-bg);
+	color:var(--muted);
+	font-size:11px;
+	line-height:1.35;
 }
 
 .settings-option:has(#setting-hide-without-discussion:checked) ~ .settings-option-hint {
@@ -10811,6 +10831,8 @@ ${
 
 <div class="settings-pane settings-pane-primary">
 
+<div id="settings-pdf-notice" class="settings-notice" hidden>Backchannel not supported in Firefox's PDF viewer</div>
+
 <div class="settings-group">
 <label class="settings-option">
 <input id="setting-auto-open-sidebar" data-setting="autoOpenSidebar" type="checkbox">
@@ -10856,8 +10878,8 @@ Highlights the passages commenters quote, so you can jump between the article an
 </label>
 <div class="settings-option-hint">
 The default PDF reader will be replaced with
-<a href="https://mozilla.github.io/pdf.js/" target="_blank" rel="noreferrer noopener">pdf.js</a>,
-allowing highlighting and annotation directly onto the PDF.
+<a href="https://mozilla.github.io/pdf.js/" target="_blank" rel="noreferrer noopener">pdf.js</a>
+to allow highlighting and annotation directly onto PDFs.
 </div>
 </div>
 <div class="settings-option-row">
@@ -11178,6 +11200,24 @@ ${[
 
 				for (const input of group.querySelectorAll("input")) {
 					input.disabled = !enabled;
+				}
+			}
+
+			if (pdfViewerRefusesExtensions()) {
+				const option = settingsInputs.pdfReader?.closest(".settings-option");
+				const hint = option?.nextElementSibling;
+				const notice = shadow.querySelector("#settings-pdf-notice");
+
+				if (option) {
+					option.hidden = true;
+				}
+
+				if (hint?.classList.contains("settings-option-hint")) {
+					hint.hidden = true;
+				}
+
+				if (notice) {
+					notice.hidden = false;
 				}
 			}
 		};

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -10840,7 +10840,7 @@ When off, pages with no discussion get a greyed-out button that offers to submit
 <div class="settings-group">
 <label class="settings-option">
 <input id="setting-annotations" data-setting="annotations" type="checkbox">
-<span>Enable article annotations <span class="op-pill">BETA</span></span>
+<span>Enable annotations <span class="op-pill">BETA</span></span>
 </label>
 <div class="settings-option-hint">
 Highlights the passages commenters quote, so you can jump between the article and what was said about it.

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -3577,7 +3577,7 @@ ${
 			bodyHTML: "",
 			rootKeys: notes.map((note) => sourceKey("notes", note.id)),
 			rootTimes: notes.map((note) => note.created || 0),
-			notes,
+			notes: [...notes].sort((a, b) => (b.created || 0) - (a.created || 0)),
 		};
 	}
 	// #endregion hnewhere-test-export
@@ -3972,6 +3972,7 @@ button {
 	}
 	// #endregion hnewhere-test-export
 
+	// #region hnewhere-test-export
 	function settleNotepad(node) {
 		const body = node?.closest?.(".notepad-body");
 		const section = body?.closest(".notepad-section");
@@ -3980,8 +3981,14 @@ button {
 			return;
 		}
 
+		if (body.querySelector(".note-editor")) {
+			body.style.maxHeight = "";
+			return;
+		}
+
 		body.style.maxHeight = body.scrollHeight ? `${body.scrollHeight}px` : "";
 	}
+	// #endregion hnewhere-test-export
 
 	function openNotepad(section) {
 		const body = section?.querySelector(".notepad-body");
@@ -10570,16 +10577,13 @@ The default PDF reader will be replaced with
 allowing highlighting and annotation directly onto the PDF.
 </div>
 </div>
-</div>
-
-<div class="settings-group">
 <label class="settings-option">
 <input id="setting-notepad" data-setting="notepad" type="checkbox">
 <span>Enable notepad</span>
 </label>
 <div class="settings-option-hint">
-Write your own notes on any page or PDF, on a passage you select or on the page
-as a whole. They stay on this device and are never sent anywhere.
+Write your own notes on any article or PDF, with support for annotating a
+passage you select. Stored locally.
 </div>
 </div>
 
@@ -13870,6 +13874,7 @@ ${settingsPanelHTML()}
 
 		if (settings.notepad) {
 			const held = notesSection({
+				empty: !notes.length,
 				onAdd: () => startNotepadDraft(held.section, held.body),
 			});
 
@@ -14093,7 +14098,7 @@ ${settingsPanelHTML()}
 	}
 
 	// #region hnewhere-test-export
-	function notesSection({ onAdd } = {}) {
+	function notesSection({ onAdd, empty = false } = {}) {
 		const section = document.createElement("div");
 		const head = document.createElement("div");
 		const body = document.createElement("div");
@@ -14109,8 +14114,14 @@ ${settingsPanelHTML()}
 
 		toggle.type = "button";
 		toggle.className = "notepad-toggle";
-		toggle.textContent = "hide";
-		toggle.setAttribute("aria-expanded", "true");
+		toggle.textContent = empty ? "show" : "hide";
+		toggle.hidden = empty;
+		toggle.setAttribute("aria-expanded", empty ? "false" : "true");
+
+		if (empty) {
+			section.classList.add("is-collapsed");
+			body.style.maxHeight = "0px";
+		}
 		toggle.onclick = () => {
 			const collapsed = !section.classList.contains("is-collapsed");
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See what everyone's talking about.
 - **What the internet is saying, in one thread:** Every source you've switched on, merged into a single conversation, each comment quietly noting where it came from. Pick them with a checkbox.
 - **See what they're talking about:** Quotes in the comments get matched back to the article and lit as annotations in articles. Click a highlight to filter the thread to the people discussing that passage.
    - _Currently in beta. **Enable Annotations** in the settings menu to try it out!_ 
-   - **NEW:** Enable **Enhanced PDF support** to get highlighting directly on PDF documents.
+   - **NEW:** Enable **Enhanced PDF support** to get highlighting directly on PDF documents. (Not supported on Firefox)
 - **Read, then join in:** Vote, reply, and even submit on supported sources. It acts in a popup on the source's own site, using the session you already have there. The script never sees your password.
 - **Take notes across the web:** Add notes to any page or PDF you visit, allowing you to have your own personal commentary track. All stored locally.
 - **New front page of the internet**: Blend together all of your added sources to create a custom front page to find new articles to read.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ See what everyone's talking about.
 - **Never miss a thread:** Every page you land on gets checked against the sources you've picked, so you find out a discussion exists without going hunting for one.
 - **What the internet is saying, in one thread:** Every source you've switched on, merged into a single conversation, each comment quietly noting where it came from. Pick them with a checkbox.
 - **See what they're talking about:** Quotes in the comments get matched back to the article and lit as annotations in articles. Click a highlight to filter the thread to the people discussing that passage.
-   - _Currently in beta. Enable Annotations in the settings menu to try it out!_ 
+   - _Currently in beta. **Enable Annotations** in the settings menu to try it out!_ 
+   - **NEW:** Enable **Enhanced PDF support** to get highlighting directly on PDF documents.
 - **Read, then join in:** Vote, reply, and even submit on supported sources. It acts in a popup on the source's own site, using the session you already have there. The script never sees your password.
+- **Take notes across the web:** Add notes to any page or PDF you visit, allowing you to have your own personal commentary track. All stored locally.
 - **New front page of the internet**: Blend together all of your added sources to create a custom front page to find new articles to read.
 - **Quality of life:** Indent guides, OP marking, and new comment highlighting.
 - **Yours to adjust:** Button shape and size, sidebar width, theme, which annotation layers show, and a per-site off switch. It's one file with no build step, so if the settings don't cover it, the source is right there.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,8 @@
 
 ## Supported versions
 
-Backchannel — formerly HNewhere — is distributed as a single userscript that auto-updates from `main`.
-Only the latest release is supported — there are no maintenance branches, and a
+Backchannel (formerly HNewhere) is distributed as a single userscript that auto-updates from `main`.
+Only the latest release is supported -- there are no maintenance branches, and a
 fix ships as a new version that existing installs pick up automatically.
 
 | Version | Supported |
@@ -40,28 +40,28 @@ Worth stating plainly, because the permissions are broad by necessity:
   | Source | Hosts contacted | What they are told |
   | --- | --- | --- |
   | Hacker News | `hn.algolia.com`, `hacker-news.firebaseio.com`, `news.ycombinator.com` | the URL of each page you visit, with no persistent identifier attached |
-  | Reddit | `www.reddit.com` | the URL of each page you visit. **Signed in to Reddit, these requests arrive authenticated as your account**; signed out, they carry a long-lived device identifier |
+  | Reddit | `www.reddit.com` | the URL of each page you visit. Signed in to Reddit, these requests arrive authenticated as your account; signed out, they carry a long-lived device identifier |
   | Reddit (fallback) | `arctic-shift.photon-reddit.com` | the URL of each page you visit, with no identifier. Used automatically when reddit.com declines the request |
   | Bluesky (discovery) | `constellation.microcosm.blue` | the URL of each page you visit, with no identifier attached |
-  | Bluesky | `public.api.bsky.app` | post identifiers only — **never the URL of the page you are on** |
-  | Lobsters | `lobste.rs` | the **domain** of each page you visit — never the full address. It has no URL search, so the exact match is made here |
+  | Bluesky | `public.api.bsky.app` | post identifiers only -- never the URL of the page you are on |
+  | Lobsters | `lobste.rs` | the domain of each page you visit -- never the full address. It has no URL search, so the exact match is made here |
   | Wikipedia | `en.wikipedia.org` | the URL of each page you visit, to find the Talk pages citing it, and then those pages' names to read what was said. No account, signed in or out |
   | Lemmy | `lemmy.world` | the URL of each page you visit, with no account |
-  | Mastodon (discovery) | `www.tootfinder.ch` | the **domain** of each page you visit — never the full address. An opt-in index of Mastodon posts, not Mastodon, and it holds only people who chose to be searchable |
-  | Mastodon (front page) | `mastodon.social` | **nothing about you.** Asked only what that instance is currently linking to |
+  | Mastodon (discovery) | `www.tootfinder.ch` | the domain of each page you visit -- never the full address. An opt-in index of Mastodon posts, not Mastodon, and it holds only people who chose to be searchable |
+  | Mastodon (front page) | `mastodon.social` | nothing about you. Asked only what that instance is currently linking to |
   | Hypothes.is | `api.hypothes.is` | the URL of each page you visit, to find public annotations on it. No account, signed in or out |
-  | *no source enabled* | none | nothing — the script performs no lookup at all |
+  | *no source enabled* | none | nothing -- the script performs no lookup at all. Kind of weird to use it this way, but no judgements. |
 
   Two hosts sit outside that table because they are not lookups:
 
   | Host | When | What it is told |
   | --- | --- | --- |
   | `old.reddit.com` | only when you press vote or reply | the comment you are acting on, in a popup window you can see. Nothing at page load |
-  | `cdn.jsdelivr.net` | when your manager fetches the script's declared resources, and again from the page itself if it did not | nothing about you — it is a file download of a fixed, versioned URL |
+  | `cdn.jsdelivr.net` | when your manager fetches the script's declared resources, and again from the page itself if it did not | nothing about you -- it is a file download of a fixed, versioned URL |
 
 - **Enhanced PDF support downloads a copy of pdf.js.** The reader is
   [pdf.js](https://mozilla.github.io/pdf.js/), declared as two `@resource` files
-  on `cdn.jsdelivr.net` — 0.49 MiB for the viewer and 1.25 MiB for its worker,
+  on `cdn.jsdelivr.net` -- 0.49 MiB for the viewer and 1.25 MiB for its worker,
   1.74 MiB in all, pinned to one version rather than tracking latest. Your
   userscript manager fetches declared resources for you; if it hands back
   nothing, the script fetches the same two URLs itself when the reader opens.
@@ -71,11 +71,11 @@ Worth stating plainly, because the permissions are broad by necessity:
   why the setting is off until you turn it on.
 - **Reading a PDF means reading the file you already have open.** With the
   setting off, the script asks the browser's own viewer for the document's text.
-  With it on, the script's own reader parses the bytes instead — the same bytes
+  With it on, the script's own reader parses the bytes instead -- the same bytes
   your browser downloaded to show you. Either way a quoted passage can be found
   on a page that is not on screen yet, and either way nothing about the document
   is sent anywhere.
-- **None of this happens in Firefox.** Firefox reserves its built-in PDF viewer
+   - **None of this happens in Firefox.** Firefox reserves its built-in PDF viewer
   and lets no extension run there, userscript managers included, so on a PDF the
   script never starts: nothing is read, no host is contacted, and no button or
   sidebar appears. This is a limit of the browser rather than a setting, and it
@@ -84,52 +84,7 @@ Worth stating plainly, because the permissions are broad by necessity:
   it lists every host any source *could* contact, including sources you have
   switched off. A disabled source issues no requests; the entry is a permission
   the script is allowed but does not exercise.
-- **Reddit is off by default, and is a real trade.** Enabling it sends your
-  browsing to a company whose business is advertising.
-
-  How much it reveals depends on whether you are signed in, and this was
-  measured rather than assumed. Reddit sets two session cookies. `token_v2` is
-  `SameSite=Lax` and is withheld from cross-site requests — but signing in also
-  sets **`reddit_session`, which is `SameSite=None`** and is not. So a request
-  this script makes from an unrelated page arrives at Reddit **authenticated as
-  your account**: asked who is calling, Reddit answers with your username.
-  Signed out, the same request carries only `loid`, a device identifier that
-  persists for over a year — and which Reddit can associate with your account
-  anyway if you have ever signed in on that browser.
-
-  Hacker News and Algolia receive URLs with no per-user identifier at all. This
-  is why Reddit is a checkbox rather than a default, and why the caveat sits
-  next to the checkbox rather than only here. Enabling *Never contact Reddit
-  directly* uses only the archive mirror, which receives no identifier and no
-  session.
-- **Reddit can vote and reply, and only when you press something.** This changed
-  in 1.6.7; before that it was read-only. Both act the same way Hacker News does:
-  a popup window opens on `old.reddit.com`, uses the session your browser already
-  holds there, and closes. The script never handles your Reddit password and
-  never moves your session cookie anywhere. It cannot submit — there is no
-  posting a new link or a new thread to Reddit.
-- **Bluesky is off by default, read-only, and needs no account.** The trade is a
-  different shape from Reddit's, and better in one specific way: the page you are
-  reading is disclosed to *Constellation*, not to Bluesky. Bluesky's own API is
-  asked only which posts Constellation named, so it learns which posts you looked
-  at and not which page you are on.
-
-  Constellation is run by the [microcosm](https://microcosm.blue) project — a
-  small independent operator rather than a company, self-hostable, and it asks
-  callers to identify themselves in a `User-Agent`, which this script does. That
-  cuts both ways and is worth knowing in both directions: there is no advertising
-  business behind it, and also no company behind it.
-
-  Measured 2026-08-05, and the Reddit case above is exactly why it was measured
-  rather than assumed. **Signed in to Bluesky, the cookie jar for `bsky.app` is
-  empty** — it authenticates with tokens in local storage, which the browser
-  never attaches to a request. There is no credential for these requests to
-  carry, signed in or out. Separately, `public.api.bsky.app` returns
-  byte-identical responses whether handed a cookie, a bearer token or nothing at
-  all, and answers `501 Method Not Implemented` to the one auth-gated method
-  tried: it has no authenticated mode to leak into. Two independent reasons,
-  either of which would be sufficient.
-- **It stores data locally** through `GM.getValue` / `GM.setValue` — settings,
+- **It stores data locally** through `GM.getValue` / `GM.setValue` -- settings,
   per-site sidebar widths, button position, collapsed threads, seen-comment
   timestamps, remembered votes and favourites, your reading queue, the sites you
   have hidden, and anything you write in the notepad. Nothing is sent anywhere
@@ -148,19 +103,19 @@ Worth stating plainly, because the permissions are broad by necessity:
 - **Sensitive sites are excluded** both in the userscript header and at runtime.
   `isHiddenSite()` blocks anything that is not `http` or `https`, private and
   single-label hostnames, and a list covering webmail, banking, auth flows and
-  cloud consoles — matched on the hostname and on the path, so a sign-in page
+  cloud consoles -- matched on the hostname and on the path, so a sign-in page
   is caught on a host that is otherwise fine. A blocked page
   performs no lookup, renders nothing, and writes no stored state. PDFs were on
   that list until 1.6.7; they are read like any other page now, and a PDF on an
   excluded host stays excluded.
-- **Credentials never leave the site they belong to.** Everything that writes —
+- **Credentials never leave the site they belong to.** Everything that writes --
   voting, replying, and submitting on Hacker News; voting and replying on Reddit
-  — happens in a popup window on that site's own domain, using the session your
+  -- happens in a popup window on that site's own domain, using the session your
   browser already has there. The script never handles either password and never
   posts a session cookie anywhere. Those two are the only sources with write
   access; the rest are read-only.
 - **Comment HTML is sanitized** before being inserted, through an allowlist of
-  tags and attributes — applied to every source. Reddit's rendered markdown
+  tags and attributes -- applied to every source. Reddit's rendered markdown
   arrives HTML-escaped and is unescaped only to be handed to the same sanitizer.
   Lemmy hands over Markdown rather than HTML, which is escaped first and only
   then turned into links and quotes, so the only markup in a Lemmy comment is
@@ -169,9 +124,11 @@ Worth stating plainly, because the permissions are broad by necessity:
   reach into it by accident, and its styles do not leak onto the page.
 - **`@noframes`** keeps it out of iframes.
 
+## Exact table of what each source requests
+
 ## Out of scope
 
-- Vulnerabilities in your userscript manager, browser, or Hacker News itself —
+- Vulnerabilities in your userscript manager, browser, or sources themselves --
   please report those to their maintainers.
 - The script's ability to read pages you visit. That is inherent to what a
   userscript is, and is disclosed above rather than treated as a flaw. If you

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -126,6 +126,39 @@ Worth stating plainly, because the permissions are broad by necessity:
 
 ## Exact table of what each source requests
 
+One row per request the script can make, read from the code rather than described.
+`<page>` is the address of the page you are on; `<domain>` is only its host. A
+source you have not switched on issues none of these.
+
+| Source | Request | What it carries | Arrives as you? |
+| --- | --- | --- | --- |
+| Hacker News | `GET hn.algolia.com/api/v1/search?tags=story&restrictSearchableAttributes=url&hitsPerPage=20&query=<page>` | `<page>` | No, and no identifier of any kind |
+| Hacker News | `GET hacker-news.firebaseio.com/v0/item/<id>` | story and comment ids it already has | No |
+| Hacker News | `GET news.ycombinator.com/item?id=<id>` | a thread id, to read scores and flags | Yes, if you are signed in there |
+| Reddit | `GET www.reddit.com/search.json?type=link&limit=25&q=<page>` | `<page>` | Yes when signed in. `reddit_session` is `SameSite=None`, so the browser attaches it cross-site. Signed out it carries `loid`, a device id that lasts over a year |
+| Reddit (fallback) | `GET arctic-shift.photon-reddit.com<path>` | the same lookup, against an archive mirror | No identifier, no session |
+| Reddit (vote, reply) | popup window on `old.reddit.com` | the one comment you acted on, only when you press | Yes, in a window you can see, using the session already in your browser |
+| Bluesky | `GET constellation.microcosm.blue/links/all?target=<page>` | `<page>`, plus a `User-Agent` naming Backchannel and its version | No |
+| Bluesky | `GET constellation.microcosm.blue/xrpc/blue.microcosm.links.getBacklinks?subject=<page>&source=...&limit=100` | `<page>` | No |
+| Bluesky | `GET public.api.bsky.app/xrpc/app.bsky.feed.getPosts` and `...getPostThread` | post ids Constellation named, never `<page>` | No. Signed in, the cookie jar for `bsky.app` is empty -- it authenticates from local storage, which the browser never attaches |
+| Lobsters | `GET lobste.rs/domains/<domain>.json` | `<domain>` only, never the full address | No |
+| Wikipedia | `GET en.wikipedia.org/w/api.php?action=query&list=exturlusage&eunamespace=1\|3\|4\|5&euquery=<page>&eulimit=100` | `<page>`, to find the Talk and project pages citing it | No |
+| Wikipedia | `GET en.wikipedia.org/w/api.php?action=query&prop=revisions&titles=<titles>` | the names of those pages | No |
+| Lemmy | `GET lemmy.world/api/v3/search?q=<page>&type_=Url&listing_type=All&limit=20` | `<page>` | No |
+| Lemmy | `GET lemmy.world/api/v3/comment/list?post_id=<id>&type_=All&sort=Top&max_depth=8&limit=300` | a post id it already found | No |
+| Mastodon | `GET www.tootfinder.ch/rest/api/search/<domain>` | `<domain>` only, never the full address | No |
+| Mastodon (front page) | `GET mastodon.social/api/v1/trends/links?limit=40` | nothing about you, only what that instance is linking to | No |
+| Hypothes.is | `GET api.hypothes.is/api/search?url=<page>&limit=200` | `<page>` | No |
+| pdf.js, not a source | `GET cdn.jsdelivr.net/npm/pdfjs-dist@<version>/legacy/build/pdf.min.mjs` and `pdf.worker.min.mjs` | nothing about you, two fixed files at a pinned version | No |
+| no source enabled | none | nothing, no lookup is performed at all | -- |
+
+Two rows are worth reading twice. Reddit is the only source that learns who you
+are, which is why it is a checkbox rather than a default and why the caveat sits
+next to that checkbox; *Never contact Reddit directly* uses only the archive
+mirror row, which carries neither a session nor an identifier. Bluesky never
+learns which page you are on -- Constellation does, and Bluesky is asked only
+about the posts Constellation named.
+
 ## Out of scope
 
 - Vulnerabilities in your userscript manager, browser, or sources themselves --

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ fix ships as a new version that existing installs pick up automatically.
 
 | Version | Supported |
 | ------- | --------- |
-| 1.6.1   | Yes       |
-| < 1.6.1 | No        |
+| 1.6.8   | Yes       |
+| < 1.6.8 | No        |
 
 Your installed version is shown at the bottom of the settings panel.
 
@@ -52,10 +52,29 @@ Worth stating plainly, because the permissions are broad by necessity:
   | Hypothes.is | `api.hypothes.is` | the URL of each page you visit, to find public annotations on it. No account, signed in or out |
   | *no source enabled* | none | nothing — the script performs no lookup at all |
 
-- **Reading a PDF means reading the viewer.** On a PDF the script asks the
-  browser's own viewer for the document's text, so a quoted passage can be found
-  on a page that is not on screen yet. That is a read of the file you already
-  have open; nothing about it is sent anywhere.
+  Two hosts sit outside that table because they are not lookups:
+
+  | Host | When | What it is told |
+  | --- | --- | --- |
+  | `old.reddit.com` | only when you press vote or reply | the comment you are acting on, in a popup window you can see. Nothing at page load |
+  | `cdn.jsdelivr.net` | when your manager fetches the script's declared resources, and again from the page itself if it did not | nothing about you — it is a file download of a fixed, versioned URL |
+
+- **Enhanced PDF support downloads a copy of pdf.js.** The reader is
+  [pdf.js](https://mozilla.github.io/pdf.js/), declared as two `@resource` files
+  on `cdn.jsdelivr.net` — 0.49 MiB for the viewer and 1.25 MiB for its worker,
+  1.74 MiB in all, pinned to one version rather than tracking latest. Your
+  userscript manager fetches declared resources for you; if it hands back
+  nothing, the script fetches the same two URLs itself when the reader opens.
+  Either way it is a file download from a CDN, it carries nothing about you, and
+  the code is only loaded into a page when the setting is on and you are on a
+  PDF. This is the one thing in the script that is not self-contained, which is
+  why the setting is off until you turn it on.
+- **Reading a PDF means reading the file you already have open.** With the
+  setting off, the script asks the browser's own viewer for the document's text.
+  With it on, the script's own reader parses the bytes instead — the same bytes
+  your browser downloaded to show you. Either way a quoted passage can be found
+  on a page that is not on screen yet, and either way nothing about the document
+  is sent anywhere.
 - **`@connect` is a ceiling, not a statement of use.** The header is static, so
   it lists every host any source *could* contact, including sources you have
   switched off. A disabled source issues no requests; the entry is a permission
@@ -78,8 +97,12 @@ Worth stating plainly, because the permissions are broad by necessity:
   next to the checkbox rather than only here. Enabling *Never contact Reddit
   directly* uses only the archive mirror, which receives no identifier and no
   session.
-- **Reddit is read-only.** No voting, no replying, no submitting. Nothing is ever
-  posted to Reddit on your behalf.
+- **Reddit can vote and reply, and only when you press something.** This changed
+  in 1.6.7; before that it was read-only. Both act the same way Hacker News does:
+  a popup window opens on `old.reddit.com`, uses the session your browser already
+  holds there, and closes. The script never handles your Reddit password and
+  never moves your session cookie anywhere. It cannot submit — there is no
+  posting a new link or a new thread to Reddit.
 - **Bluesky is off by default, read-only, and needs no account.** The trade is a
   different shape from Reddit's, and better in one specific way: the page you are
   reading is disclosed to *Constellation*, not to Bluesky. Bluesky's own API is
@@ -102,27 +125,41 @@ Worth stating plainly, because the permissions are broad by necessity:
   tried: it has no authenticated mode to leak into. Two independent reasons,
   either of which would be sufficient.
 - **It stores data locally** through `GM.getValue` / `GM.setValue` — settings,
-  per-site sidebar widths, collapsed threads, seen-comment timestamps, and
-  remembered votes. Nothing is sent anywhere except the hosts above.
+  per-site sidebar widths, button position, collapsed threads, seen-comment
+  timestamps, remembered votes and favourites, your reading queue, the sites you
+  have hidden, and anything you write in the notepad. Nothing is sent anywhere
+  except the hosts above.
+- **The notepad stays on the machine you wrote it on.** Notes live in your
+  userscript manager's storage, keyed by page address or, on a PDF, by the
+  document's fingerprint. Nothing is uploaded and no source is told they exist.
+  That cuts the other way too: they do not sync between browsers, and clearing
+  your manager's data takes them with it, which is why the setting offers an
+  export.
 - **There is no backend, no analytics, and no telemetry.** Nobody but you and the
   sources you have enabled sees which pages you look up.
 
 ## Design decisions that limit the blast radius
 
 - **Sensitive sites are excluded** both in the userscript header and at runtime.
-  `isHiddenSite()` blocks private and single-label hostnames, plus a list
-  covering webmail, banking, auth flows, and cloud consoles. A blocked page
+  `isHiddenSite()` blocks anything that is not `http` or `https`, private and
+  single-label hostnames, and a list covering webmail, banking, auth flows and
+  cloud consoles — matched on the hostname and on the path, so a sign-in page
+  is caught on a host that is otherwise fine. A blocked page
   performs no lookup, renders nothing, and writes no stored state. PDFs were on
   that list until 1.6.7; they are read like any other page now, and a PDF on an
   excluded host stays excluded.
-- **Credentials never leave Hacker News.** Voting, submitting, and commenting are
-  performed in a popup window on `news.ycombinator.com` using your existing
-  session there. The script never handles your HN password, and never posts your
-  session cookie anywhere. No other source has write access at all.
+- **Credentials never leave the site they belong to.** Everything that writes —
+  voting, replying, and submitting on Hacker News; voting and replying on Reddit
+  — happens in a popup window on that site's own domain, using the session your
+  browser already has there. The script never handles either password and never
+  posts a session cookie anywhere. Those two are the only sources with write
+  access; the rest are read-only.
 - **Comment HTML is sanitized** before being inserted, through an allowlist of
-  tags and attributes — applied to every source, including Reddit's rendered
-  markdown, which arrives HTML-escaped and is unescaped only to be handed to the
-  same sanitizer.
+  tags and attributes — applied to every source. Reddit's rendered markdown
+  arrives HTML-escaped and is unescaped only to be handed to the same sanitizer.
+  Lemmy hands over Markdown rather than HTML, which is escaped first and only
+  then turned into links and quotes, so the only markup in a Lemmy comment is
+  markup this script wrote.
 - **The UI renders inside shadow roots**, so page styles and page scripts do not
   reach into it by accident, and its styles do not leak onto the page.
 - **`@noframes`** keeps it out of iframes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,6 +75,11 @@ Worth stating plainly, because the permissions are broad by necessity:
   your browser downloaded to show you. Either way a quoted passage can be found
   on a page that is not on screen yet, and either way nothing about the document
   is sent anywhere.
+- **None of this happens in Firefox.** Firefox reserves its built-in PDF viewer
+  and lets no extension run there, userscript managers included, so on a PDF the
+  script never starts: nothing is read, no host is contacted, and no button or
+  sidebar appears. This is a limit of the browser rather than a setting, and it
+  applies whatever Enhanced PDF support is set to.
 - **`@connect` is a ceiling, not a statement of use.** The header is static, so
   it lists every host any source *could* contact, including sources you have
   switched off. A disabled source issues no requests; the entry is a permission


### PR DESCRIPTION
# v1.6.8

## Features
- You can now directly annotate/comment on PDFs
   - Off by default (enable in **Settings** > **Enable annotations** > **Enhanced PDF support**). Enabling will replace your browser's default PDF reader with pdf.js, allowing for parsing/markup
- You now have a local notepad to write your own comments/annotations and store them locally
   - Notes are exportable if you want to take them elsewhere
   - Add you own annotations to a page by quoting text from articles/PDFs (required Enhanced PDF support)

## Fixes
- Lemmy comments should render their Markdown correctly now
- Fixed a bug where one quoted passage overlapping another could break all highlights
- Better support for quoting across line breaks (you may still see some issues, will continue working on it)
- Cleanup queue styling