### PR TITLE
v1.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,20 @@ use to detect updates, so every release bumps it.
   the notification only decides whether you are told before you look.
 
 - **Collection**, a third tab beside front pages and queue, holding what you have
-  kept rather than what you are working through: favourites, favourited comments,
-  and every page you have written a note on, each under its own heading.
+  kept rather than what you are working through, under three headings: favorite
+  discussions, favorite comments, and noted. A comment and a note are a piece of
+  writing rather than a headline, so each is shown as itself — set as a quote,
+  cut to a line — above who wrote it and which discussion or page it is in.
+  Opening a favorited comment loads the page its discussion is about and focuses
+  that comment. **noted** lists your notes one by one, newest first, each with an
+  **edit** and a **delete** that reach the note itself rather than just the row —
+  so the place you go to find a note you wrote elsewhere is a place you can
+  change it. Nothing in the collection is numbered; the rows are told apart by
+  the room between them.
 
-- **Favourites are kept here rather than on the source**, which is what lets them
+- **Favorites are kept here rather than on the source**, which is what lets them
   work everywhere — Bluesky, Mastodon, Lemmy and Hypothes.is have no way to
-  favourite anything, and a favourite that only worked on some of your sources
+  favorite anything, and a favorite that only worked on some of your sources
   would be a stranger thing than one that works on all of them. Nothing is sent
   to your account.
 
@@ -52,23 +60,72 @@ use to detect updates, so every release bumps it.
   queue, where it clears like anything else.
 
 - **un-favorite** is **unfavorite**, and **remove** in the queue is **unqueue**,
-  matching unflag and unwatch.
+  matching unwatch.
 
 - **favorite keeps an item here rather than favouriting it on Hacker News.** It
   used to do the latter, through the same popup vote and reply use. Every source
   has some equivalent of favouriting and only Hacker News could be wired to it,
-  so it is kept locally for now and works on all of them. **flag** is unchanged
-  and still goes to Hacker News.
+  so it is kept locally for now and works on all of them.
+
+- **favorite is on everything there is to keep**, rather than on Hacker News
+  alone: every source's discussions, in both the front pages and the queue, and
+  every comment in them. A favorited item now says **unfavorite** wherever it
+  appears, which it did not when the label was still asking Hacker News.
+
+- A page carrying several discussions is favorited as a page. **favorite** sits
+  beside watch above them, keeping the page rather than picking one of them.
+
+- A watched page keeps its colour once read. The bullet beside it already says
+  whether there is anything new, and a watch is something you asked to keep
+  hearing about.
 
 - The **BETA** pills are gone from the sources. Every source carried one, which
   made it say nothing about any of them. **Favorite** and **Flag** have gone from
-  What each source supports for the same reason — favourites are kept here, so
+  What each source supports for the same reason — favorites are kept here, so
   there is nothing per-source to report.
 
 - The explanation under Enable notepad folds away when it is ticked, the way the
   other settings' explanations do.
 
+### Removed
+
+- **flag** is gone. It was Hacker News's alone, it could not be offered anywhere
+  else, and it is the one thing here that asks a moderator to act rather than
+  keeping something for you. Flagging is where it always was, on the item's own
+  page.
+
 ### Fixed
+
+- **Queueing a story only worked once.** A front page row names no key of its
+  own, so the first story queued stored an empty one and every story queued
+  after it was read as the same story and dropped without a word. (#107)
+
+- The top of the field was cut off when you started a note, and the note saying
+  a quoted passage was not found was cut off below **save** and painted under
+  the note beneath it. The draft gives up the clipping it slides open with once
+  it is open.
+
+- Editing or deleting a note from **collection** while reading a different
+  article moved that note to the article you were reading. A note keeps the
+  address it was written at.
+
+- The notepad sat below every comment on a discussion from a single source, and
+  **favorite** was missing from that discussion's byline. Both now read the way
+  a blended discussion already did.
+
+- Filtering a blended discussion to one of its sources took your notes away with
+  it, and writing a note dropped the filter and put the blend back. Notes belong
+  to the page rather than to any one discussion of it, and the filter survives.
+
+- A settings checkbox sat above its own label rather than centred on it, and
+  **reset** did not light up under the pointer the way **export** does.
+
+- **reset**, **Backchannel** and **Report an issue** each drew a different
+  underline in a different font. They read as **export** does, which is what
+  every other small action in the panel looks like.
+
+- The discussion count in a blended header underlines on hover, the way the
+  toggles beside it do.
 
 - Some pages changed the spacing of everything in the sidebar. The panel resets
   what a page can send into it and let one property through — line height — so a
@@ -724,7 +781,7 @@ use to detect updates, so every release bumps it.
 - **Indent guides line up with the comment they belong to.** They sat eight
   pixels past the parent's first letter, which read as a slight stagger down a
   long thread.
-- **Reply, flag and favourite no longer appear on comments that cannot take
+- **Reply, flag and favorite no longer appear on comments that cannot take
   them.** They are offered where the source supports them and nowhere else; on
   Reddit they would have acted on an item id Hacker News never issued.
 - **A switched-off source stays off, whichever way the panel is opened.** The URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ use to detect updates, so every release bumps it.
   a watch that cannot be answered several times running says so instead of
   waiting silently.
 
-- **Notify me when a watched discussion has something new**, under Enable
+- **Enable notifications for updates to watched discussions**, under Enable
   notepad in settings. Off to begin with, and ticking it is what asks for
   permission to send notifications. Left off, a watch still lands in your queue —
   the notification only decides whether you are told before you look.
@@ -98,7 +98,9 @@ use to detect updates, so every release bumps it.
 
 - **Queueing a story only worked once.** A front page row names no key of its
   own, so the first story queued stored an empty one and every story queued
-  after it was read as the same story and dropped without a word. (#107)
+  after it was read as the same story and dropped without a word. Entries
+  already saved that way could not be removed either, and were cleared even
+  where the page was being watched. (#107)
 
 - The top of the field was cut off when you started a note, and the note saying
   a quoted passage was not found was cut off below **save** and painted under
@@ -117,8 +119,9 @@ use to detect updates, so every release bumps it.
   it, and writing a note dropped the filter and put the blend back. Notes belong
   to the page rather than to any one discussion of it, and the filter survives.
 
-- A settings checkbox sat above its own label rather than centred on it, and
-  **reset** did not light up under the pointer the way **export** does.
+- A settings checkbox sat below the line of its own label. It is centred on that
+  line now, and a little larger, so it nearly fills it. **reset** lights up under
+  the pointer the way **export** does.
 
 - **reset**, **Backchannel** and **Report an issue** each drew a different
   underline in a different font. They read as **export** does, which is what

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ use to detect updates, so every release bumps it.
 - **un-favorite** is **unfavorite**, and **remove** in the queue is **unqueue**,
   matching unflag and unwatch.
 
+- **favorite keeps an item here rather than favouriting it on Hacker News.** It
+  used to do the latter, through the same popup vote and reply use. Every source
+  has some equivalent of favouriting and only Hacker News could be wired to it,
+  so it is kept locally for now and works on all of them. **flag** is unchanged
+  and still goes to Hacker News.
+
+- The **BETA** pills are gone from the sources. Every source carried one, which
+  made it say nothing about any of them. **Favorite** and **Flag** have gone from
+  What each source supports for the same reason — favourites are kept here, so
+  there is nothing per-source to report.
+
 - The explanation under Enable notepad folds away when it is ticked, the way the
   other settings' explanations do.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ use to detect updates, so every release bumps it.
 
 - **Watch a page, and be told when someone starts talking about it.** Discovery
   happens once, when you land: a page nobody has posted anywhere yet is dark, and
-  stays dark however long you sit on it. **watch** in the byline keeps asking.
-  When a discussion turns up it goes into your queue as unread, and the watch
-  stops. Checks ride the page loads you were already making rather than running
-  on a schedule, so a page you never go near again is checked rarely, and a watch
-  that cannot be answered several times running says so instead of waiting
-  silently.
+  stays dark however long you sit on it. **watch**, next to the comment count,
+  keeps asking. When a discussion turns up it goes into your queue as unread, and
+  the watch stops. Checks ride the page loads you were already making rather than
+  running on a schedule, so a page you never go near again is checked rarely, and
+  a watch that cannot be answered several times running says so instead of
+  waiting silently.
 
 - **Notify me when a watched discussion has something new**, under Enable
   notepad in settings. Off to begin with, and ticking it is what asks for
@@ -30,11 +30,11 @@ use to detect updates, so every release bumps it.
   kept rather than what you are working through: favourites, favourited comments,
   and every page you have written a note on, each under its own heading.
 
-- **Favourites are kept here**, which means they work on Bluesky, Mastodon, Lemmy
-  and Hypothes.is — sources that have no way to favourite anything. Where a
-  source can do it for real, **Also favourite and flag on Hacker News** appears
-  nested under it, and only then does your account see it. Hacker News is the
-  only source that can today.
+- **Favourites are kept here rather than on the source**, which is what lets them
+  work everywhere — Bluesky, Mastodon, Lemmy and Hypothes.is have no way to
+  favourite anything, and a favourite that only worked on some of your sources
+  would be a stranger thing than one that works on all of them. Nothing is sent
+  to your account.
 
 - The number of notes you have taken sits under Enable notepad, next to export.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The version in `HNewhere.user.js`'s `@version` header is what userscript managers
 use to detect updates, so every release bumps it.
 
+## [1.6.9] — 2026-08-13
+
+### Added
+
+- **Watch a page, and be told when someone starts talking about it.** Discovery
+  happens once, when you land: a page nobody has posted anywhere yet is dark, and
+  stays dark however long you sit on it. **watch** in the byline keeps asking.
+  When a discussion turns up it goes into your queue as unread, and the watch
+  stops. Checks ride the page loads you were already making rather than running
+  on a schedule, so a page you never go near again is checked rarely, and a watch
+  that cannot be answered several times running says so instead of waiting
+  silently.
+
+- **Notify me when a watched discussion has something new**, under Enable
+  notepad in settings. Off to begin with, and ticking it is what asks for
+  permission to send notifications. Left off, a watch still lands in your queue —
+  the notification only decides whether you are told before you look.
+
+- **Collection**, a third tab beside front pages and queue, holding what you have
+  kept rather than what you are working through: favourites, favourited comments,
+  and every page you have written a note on, each under its own heading.
+
+- **Favourites are kept here**, which means they work on Bluesky, Mastodon, Lemmy
+  and Hypothes.is — sources that have no way to favourite anything. Where a
+  source can do it for real, **Also favourite and flag on Hacker News** appears
+  nested under it, and only then does your account see it. Hacker News is the
+  only source that can today.
+
+- The number of notes you have taken sits under Enable notepad, next to export.
+
+### Changed
+
+- Front pages and queue read as two halves of one page rather than two places.
+  The wordmark stays **Backchannel** across both instead of becoming
+  Backchannel / Queue, the pair sits under it rather than indented past it, and
+  moving between them slides.
+
+- A watched page with something new rises to the top of the queue, newest first,
+  marked with a filled bullet and **UNREAD**.
+
+- **clear read** leaves watched pages alone. Unwatching one drops it into the
+  queue, where it clears like anything else.
+
+- **un-favorite** is **unfavorite**, and **remove** in the queue is **unqueue**,
+  matching unflag and unwatch.
+
+- The explanation under Enable notepad folds away when it is ticked, the way the
+  other settings' explanations do.
+
+### Fixed
+
+- Some pages changed the spacing of everything in the sidebar. The panel resets
+  what a page can send into it and let one property through — line height — so a
+  page with unusual spacing reshaped the panel. (#105)
+
+- A Lemmy discussion stretched its pill out of shape under **discussions**,
+  because the community's full address is a good deal longer than `HN` or
+  `r/OpenAI`. Long names are shortened; the count stays. (#106)
+
+- A comment count reads **418+ comments** rather than 418 comments+.
+
+- A quoted passage that appears more than once in a page now anchors to the first
+  one instead of refusing to anchor at all and reporting that the passage was not
+  there.
+
+- The reason a note could not be pinned to a passage is attached to **save**,
+  where the answer is, rather than sitting beside cancel where it read as another
+  button.
+
+- A rule inside a comment is drawn as a hairline, the same as every other line in
+  the panel, rather than the browser's default groove.
+
+- The notepad's closing rule is there on first load, not only after it has been
+  opened once, and **add a note** and **show** have a separator between them.
+
 ## [1.6.8] — 2026-08-12
 
 ### Added

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -2840,7 +2840,7 @@
 		return SOURCES.get(id) || null;
 	}
 
-	function arrivalSource(referrer = document.referrer) {
+	function arrivalSource(referrer = document.referrer, sources = SOURCES.values()) {
 		let host;
 
 		try {
@@ -2849,7 +2849,7 @@
 			return null;
 		}
 
-		for (const source of SOURCES.values()) {
+		for (const source of sources) {
 			if ((source.origins || []).some((origin) => origin.toLowerCase() === host)) {
 				return source.id;
 			}
@@ -17415,12 +17415,8 @@ title="Show only this discussion">
 	// #endregion hnewhere-test-export
 
 	// #region hnewhere-test-export
-	function referrerIsHN(referrer = document.referrer) {
-		try {
-			return new URL(referrer).origin === HN_ORIGIN;
-		} catch {
-			return false;
-		}
+	function arrivedFromEnabledSource(sourceId, enabledIds) {
+		return Boolean(sourceId) && (enabledIds || []).includes(sourceId);
 	}
 
 	function shouldAutoOpenSidebar(settings, siteState = null, fromHN = false) {
@@ -17432,10 +17428,10 @@ title="Show only this discussion">
 	}
 	// #endregion hnewhere-test-export
 
-	let arrivedFromHNReferrer = referrerIsHN();
+	let arrivedFromSourceId = arrivalSource();
 
 	function forgetHNReferrer() {
-		arrivedFromHNReferrer = false;
+		arrivedFromSourceId = null;
 	}
 
 	function shouldPreloadHiddenSidebar(settings, siteState = null, fromHN = false) {
@@ -21208,7 +21204,11 @@ title="Show only this discussion">
 				stories,
 				settings,
 				siteState,
-				arrivedFromClick || arrivedFromHNReferrer,
+				arrivedFromClick ||
+					arrivedFromEnabledSource(
+						arrivedFromSourceId,
+						enabledSourceIds(settings, registeredSourceIds()),
+					),
 			);
 			return;
 		}

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -4670,6 +4670,8 @@ button {
 		return kept;
 	}
 
+	// #region hnewhere-test-export
+
 	function latestNoteExcerpt(notes) {
 		const latest = [...notes].sort(
 			(a, b) => (b.edited || b.created || 0) - (a.edited || a.created || 0),
@@ -4678,24 +4680,41 @@ button {
 		return favoriteExcerpt(latest?.text || latest?.exact || "", FAVORITE_EXCERPT_CHARS);
 	}
 
-	async function rememberNotedDocument(ref, notes) {
-		const count = notes.length;
-		const stored = await load(NOTES_INDEX_KEY, []);
-		const entries = (Array.isArray(stored) ? stored : []).filter(
-			(entry) => entry?.key !== noteStorageKey(ref),
-		);
+	function notedIndexEntry(ref, notes, previous, hereRef, here, now) {
+		const onThisPage = noteStorageKey(ref) === noteStorageKey(hereRef);
 
-		if (count > 0) {
-			entries.push({
-				key: noteStorageKey(ref),
-				kind: ref.kind,
-				id: ref.id,
-				url: location.href,
-				title: pageTitle(),
-				excerpt: latestNoteExcerpt(notes),
-				count,
-				updated: Date.now(),
-			});
+		return {
+			key: noteStorageKey(ref),
+			kind: ref.kind,
+			id: ref.id,
+			url: onThisPage ? here.url : previous?.url || "",
+			title: onThisPage ? here.title : previous?.title || "",
+			excerpt: latestNoteExcerpt(notes),
+			count: notes.length,
+			updated: now,
+		};
+	}
+
+	// #endregion hnewhere-test-export
+
+	async function rememberNotedDocument(ref, notes) {
+		const key = noteStorageKey(ref);
+		const stored = await load(NOTES_INDEX_KEY, []);
+		const list = Array.isArray(stored) ? stored : [];
+		const previous = list.find((entry) => entry?.key === key);
+		const entries = list.filter((entry) => entry?.key !== key);
+
+		if (notes.length > 0) {
+			entries.push(
+				notedIndexEntry(
+					ref,
+					notes,
+					previous,
+					noteDocumentRefForPage(),
+					{ url: location.href, title: pageTitle() },
+					Date.now(),
+				),
+			);
 		}
 
 		await save(NOTES_INDEX_KEY, entries);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -9978,7 +9978,16 @@ header button svg {
 	font-weight:600;
 }
 
+.source-strip-label {
+	min-width:0;
+	max-width:16ch;
+	overflow:hidden;
+	text-overflow:ellipsis;
+	white-space:nowrap;
+}
+
 .source-strip-count {
+	flex:0 0 auto;
 	color:var(--muted);
 	font-variant-numeric:tabular-nums;
 }

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -2981,7 +2981,7 @@
 				(source) => `
 <label class="settings-option">
 <input${idPrefix ? ` id="${escapeHTML(idPrefix + source.id)}"` : ""} data-source="${escapeHTML(source.id)}" type="checkbox">
-<span>${escapeHTML(source.label)}${source.beta ? ` <span class="op-pill">BETA</span>` : ""}${source.slow ? ` <span class="op-pill op-pill-slow" tabindex="0" role="note" aria-label="Slower comment fetch source">⧗<span class="op-pill-tip" aria-hidden="true">Slower comment fetch source</span></span>` : ""}</span>
+<span>${escapeHTML(source.label)}${source.slow ? ` <span class="op-pill op-pill-slow" tabindex="0" role="note" aria-label="Slower comment fetch source">⧗<span class="op-pill-tip" aria-hidden="true">Slower comment fetch source</span></span>` : ""}</span>
 </label>
 ${
 	source.caveat
@@ -3053,13 +3053,7 @@ ${
 		shortLabel: "HN",
 		caveat:
 			"Will send each page you visit to Algolia's Hacker News search, with no identifier attached. Vote, reply and submit through your existing HN session.",
-		capabilities: {
-			vote: true,
-			reply: true,
-			submit: true,
-			favorite: true,
-			flag: true,
-		},
+		capabilities: { vote: true, reply: true, submit: true },
 
 		profileURL: (author) =>
 			"https://news.ycombinator.com/user?id=" + encodeURIComponent(author),
@@ -3247,7 +3241,6 @@ ${
 		origins: ["reddit.com", "www.reddit.com", "old.reddit.com", "new.reddit.com"],
 		label: "Reddit",
 		shortLabel: "Reddit",
-		beta: true,
 		caveat:
 			"Will send each page you visit to reddit.com. Signed in to Reddit, those requests arrive as your account. Signed out, they carry only the long-lived device id your browser already holds. Vote and reply through your existing Reddit session.",
 		capabilities: { vote: true, reply: true, submit: false },
@@ -3459,7 +3452,6 @@ ${
 		label: "Bluesky",
 		shortLabel: "Bluesky",
 		slow: true,
-		beta: true,
 		ageLabel: "Last Bluesky comment",
 		threadArrivesWhole: true,
 		caveat:
@@ -3646,7 +3638,6 @@ ${
 		origins: ["lobste.rs"],
 		label: "Lobsters",
 		shortLabel: "Lobsters",
-		beta: true,
 		threadArrivesWhole: true,
 		caveat:
 			"Will send the domain of each page you visit to lobste.rs, not the full address. Signed in or out, these requests carry no account.",
@@ -3739,7 +3730,6 @@ ${
 		label: "Wikipedia",
 		shortLabel: "Wikipedia",
 		slow: true,
-		beta: true,
 		ageLabel: "Last active on Wikipedia",
 		threadArrivesWhole: true,
 		caveat:
@@ -3870,7 +3860,6 @@ ${
 		origins: ["hypothes.is", "web.hypothes.is"],
 		label: "Hypothes.is",
 		shortLabel: "Hypothes.is",
-		beta: true,
 		ageLabel: "Last annotation",
 		threadArrivesWhole: true,
 		caveat:
@@ -4840,7 +4829,6 @@ button {
 		label: "Mastodon",
 		shortLabel: "Mastodon",
 		slow: true,
-		beta: true,
 		ageLabel: "Last Mastodon post",
 		threadArrivesWhole: true,
 		caveat:
@@ -4941,7 +4929,6 @@ button {
 		label: "Lemmy",
 		shortLabel: "Lemmy",
 		slow: true,
-		beta: true,
 		caveat:
 			"Will send each page you visit to lemmy.world, a large Lemmy instance whose federation reaches across the network. No account, signed in or out.",
 		capabilities: { vote: false, reply: false, submit: false },
@@ -12093,8 +12080,6 @@ ${[
 	["Vote", (source) => Boolean(source.capabilities.vote)],
 	["Reply", (source) => Boolean(source.capabilities.reply)],
 	["Submit", (source) => Boolean(source.capabilities.submit)],
-	["Favorite", (source) => Boolean(source.capabilities.favorite)],
-	["Flag", (source) => Boolean(source.capabilities.flag)],
 ]
 	.map(
 		([label, supported]) => `<tr><th>${escapeHTML(label)}</th>${[

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -597,7 +597,7 @@
 
 	function removeFromQueue(entries, key) {
 		return (Array.isArray(entries) ? entries : []).filter(
-			(entry) => entry.key !== key,
+			(entry) => queueKey(entry) !== key,
 		);
 	}
 
@@ -765,7 +765,7 @@
 
 	function clearReadFromQueue(entries, keep) {
 		return (Array.isArray(entries) ? entries : []).filter(
-			(entry) => !entry.readAt || Boolean(keep?.has(entry.key)),
+			(entry) => !entry.readAt || Boolean(keep?.has(queueKey(entry))),
 		);
 	}
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -1020,20 +1020,16 @@
 			` data-favorite-kind="${escapeHTML(about.kind || "discussion")}"` +
 			` data-favorite-parent="${escapeHTML(about.parent || "")}"`;
 
-		return `
-      |
-      <button class="item-action-link" type="button"
-      data-item-action="flag" data-item-action-source="${source}" data-item-action-id="${id}">flag</button>${between}
+		return `${between}
       |
       <button class="item-action-link" type="button"
       data-item-action="fave" data-item-action-source="${source}" data-item-action-id="${id}"${meta}>favorite</button>`;
 	}
 
-	const ITEM_ACTION_FIELD = { fave: "favorite", flag: "flagged" };
+	const ITEM_ACTION_FIELD = { fave: "favorite" };
 
 	const ITEM_ACTION_LABEL = {
 		favorite: { on: "unfavorite", off: "favorite" },
-		flagged: { on: "unflag", off: "flag" },
 	};
 
 	function refreshItemActionControls(itemId) {
@@ -1095,27 +1091,20 @@
 		}
 
 		const sourceID = button.dataset.itemActionSource;
-		const action = itemActionState(itemId)?.[field] ? "un" + kind : kind;
 
 		button.disabled = true;
 
 		try {
-			if (kind === "fave") {
-				await toggleFavorite({
-					key: button.dataset.favoriteKey || `${sourceID}:${itemId}`,
-					url: button.dataset.favoriteUrl || "",
-					title: button.dataset.favoriteTitle || "",
-					site: button.dataset.favoriteSite || "",
-					kind: button.dataset.favoriteKind || "discussion",
-					source: sourceID,
-					id: itemId,
-					parent: button.dataset.favoriteParent || "",
-				});
-			}
-
-			if (kind !== "fave") {
-				await openItemActionPopup(sourceID, itemId, itemId, action, null);
-			}
+			await toggleFavorite({
+				key: button.dataset.favoriteKey || `${sourceID}:${itemId}`,
+				url: button.dataset.favoriteUrl || "",
+				title: button.dataset.favoriteTitle || "",
+				site: button.dataset.favoriteSite || "",
+				kind: button.dataset.favoriteKind || "discussion",
+				source: sourceID,
+				id: itemId,
+				parent: button.dataset.favoriteParent || "",
+			});
 		} finally {
 			button.disabled = false;
 			refreshItemActionControls(itemId);
@@ -7906,7 +7895,7 @@ button {
 			}
 
 			if (data.itemId && ITEM_ACTION_PATHS[data.action]) {
-				const field = data.action.endsWith("fave") ? "favorite" : "flagged";
+				const field = "favorite";
 
 				if (data.reason === "action-unavailable") {
 					rememberItemActionUnavailable(field);
@@ -16334,8 +16323,6 @@ title="Show only this discussion">
 	const ITEM_ACTION_PATHS = {
 		fave: { path: "fave", params: {} },
 		unfave: { path: "fave", params: { un: "t" } },
-		flag: { path: "flag", params: {} },
-		unflag: { path: "flag", params: { un: "t" } },
 	};
 
 	const VOTE_ACTIONS = ["up", "down", "un"];
@@ -16389,15 +16376,15 @@ title="Show only this discussion">
 			return null;
 		}
 
-		const isFaveOrFlag = Boolean(ITEM_ACTION_PATHS[payload.action]);
+		const isFave = Boolean(ITEM_ACTION_PATHS[payload.action]);
 
-		if (!isFaveOrFlag && location.pathname !== "/item") {
+		if (!isFave && location.pathname !== "/item") {
 			return null;
 		}
 
 		clearBridgeReload(ITEM_ACTION_BRIDGE_STORAGE_KEY);
 
-		if (isFaveOrFlag) {
+		if (isFave) {
 			const base = payload.action.startsWith("un")
 				? payload.action.slice(2)
 				: payload.action;

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -1060,7 +1060,11 @@
 			return;
 		}
 
+		const turningOn = !button.classList.contains("item-action-on");
+
 		button.disabled = true;
+		button.textContent = turningOn ? "unfavorite" : "favorite";
+		button.classList.toggle("item-action-on", turningOn);
 
 		try {
 			await toggleFavorite({
@@ -1079,7 +1083,7 @@
 			});
 		} finally {
 			button.disabled = false;
-			await refreshFavoriteControls();
+			refreshFavoriteControls().catch(console.error);
 			refreshNotedCount(sidebarUI?.shadow).catch(console.error);
 		}
 	}
@@ -10850,7 +10854,7 @@ header {
 
 .next-up {
 	display:block;
-	margin:auto -12px 24px;
+	margin:auto -12px 10px;
 	padding-top:18px;
 	font-family:Verdana, Geneva, sans-serif;
 	font-size:11px;

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -12164,7 +12164,7 @@ ${
 <div class="settings-suboptions" data-suboptions-of="autoOpenSidebar">
 <label class="settings-option sub-option">
 <input id="setting-auto-open-only-from-hn" data-setting="autoOpenSidebarOnlyFromHN" type="checkbox">
-<span>Only when arriving from Hacker News</span>
+<span>Only when arriving from an enabled source</span>
 </label>
 </div>
 <label class="settings-option">
@@ -12174,7 +12174,7 @@ ${
 <div class="settings-suboptions" data-suboptions-of="hideWithoutDiscussion">
 <label class="settings-option sub-option">
 <input id="setting-show-button-with-queue" data-setting="showButtonWithQueue" type="checkbox">
-<span>Except when something is waiting in your queue</span>
+<span>Unless there are unread items in the queue</span>
 </label>
 </div>
 </div>
@@ -12217,7 +12217,7 @@ All stored locally.
 </div>
 <label class="settings-option">
 <input id="setting-notify-on-watch" data-setting="notifyOnWatch" type="checkbox">
-<span>Notify me when a watched discussion has something new</span>
+<span>Enable notifications for updates to watched discussions</span>
 </label>
 <div class="settings-option-hint">
 Sends a system notification when a watched page has new comments

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -41,6 +41,7 @@
 // @exclude      https://*.instagram.com/*
 // @grant        GM.getValue
 // @grant        GM.setValue
+// @grant        GM.notification
 // @grant        GM.xmlHttpRequest
 // @grant        GM.getResourceText
 // @grant        unsafeWindow
@@ -195,7 +196,9 @@
 		votes: "HNewhere:votes",
 		blocked: "HNewhere:blocked_sites",
 		queue: "HNewhere:queue",
+		favorites: "HNewhere:favorites",
 		itemActions: "HNewhere:item_actions",
+		watches: "HNewhere:watches",
 	};
 
 	// #region hnewhere-test-export
@@ -352,6 +355,8 @@
 		autoOpenSidebarOnlyFromHN: false,
 		hideWithoutDiscussion: false,
 		showButtonWithQueue: false,
+		notifyOnWatch: false,
+		syncSources: {},
 		sources: undefined,
 		theme: "auto",
 		buttonShape: "circle",
@@ -593,6 +598,129 @@
 		);
 	}
 
+	const WATCH_MISS_CEILING = 5;
+
+	function addToWatchList(entries, page, now) {
+		const list = Array.isArray(entries) ? entries : [];
+
+		if (list.some((entry) => entry.key === page.key)) {
+			return list;
+		}
+
+		return [
+			...list,
+			{
+				key: page.key,
+				url: page.url,
+				title: page.title || "",
+				site: page.site || "",
+				addedAt: now,
+				checkedAt: 0,
+				marks: {},
+				misses: 0,
+				foundAt: null,
+				seenAt: null,
+			},
+		];
+	}
+
+	function addToFavorites(entries, item, now) {
+		const list = Array.isArray(entries) ? entries : [];
+
+		if (list.some((entry) => entry.key === item.key)) {
+			return list;
+		}
+
+		return [
+			...list,
+			{
+				key: item.key,
+				url: item.url,
+				title: item.title || "",
+				site: item.site || "",
+				kind: item.kind || "discussion",
+				source: item.source || "",
+				id: item.id || "",
+				parent: item.parent || "",
+				addedAt: now,
+			},
+		];
+	}
+
+	function removeFromFavorites(entries, key) {
+		return (Array.isArray(entries) ? entries : []).filter(
+			(entry) => entry.key !== key,
+		);
+	}
+
+	function favoritesOfKind(entries, kind) {
+		return (Array.isArray(entries) ? entries : []).filter(
+			(entry) => (entry.kind || "discussion") === kind,
+		);
+	}
+
+	function removeFromWatchList(entries, key) {
+		return (Array.isArray(entries) ? entries : []).filter(
+			(entry) => entry.key !== key,
+		);
+	}
+
+	function watchMarkChanged(before, after) {
+		if (after === null || after === undefined) {
+			return false;
+		}
+
+		if (before === null || before === undefined) {
+			return false;
+		}
+
+		return before !== after;
+	}
+
+	function watchesDue(entries, now, interval) {
+		return (Array.isArray(entries) ? entries : []).filter(
+			(entry) =>
+				!entry.foundAt &&
+				entry.misses < WATCH_MISS_CEILING &&
+				now - (entry.checkedAt || 0) >= interval,
+		);
+	}
+
+	function watchIsFresh(state) {
+		return Boolean(state?.foundAt && !state?.seenAt);
+	}
+
+	function sortWatchedEntries(entries, stateFor) {
+		return [...(Array.isArray(entries) ? entries : [])].sort((a, b) => {
+			const left = stateFor(a);
+			const right = stateFor(b);
+			const freshLeft = watchIsFresh(left) ? 0 : 1;
+			const freshRight = watchIsFresh(right) ? 0 : 1;
+
+			if (freshLeft !== freshRight) {
+				return freshLeft - freshRight;
+			}
+
+			if (freshLeft === 0) {
+				return (right?.foundAt || 0) - (left?.foundAt || 0);
+			}
+
+			return 0;
+		});
+	}
+
+	function unseenWatchCount(entries) {
+		return (Array.isArray(entries) ? entries : []).filter(
+			(entry) => entry.foundAt && !entry.seenAt,
+		).length;
+	}
+
+	function stalledWatchCount(entries) {
+		return (Array.isArray(entries) ? entries : []).filter(
+			(entry) => !entry.foundAt && entry.misses >= WATCH_MISS_CEILING,
+		).length;
+	}
+
 	function migrateQueueKeys(entries, normalize) {
 		return (Array.isArray(entries) ? entries : []).map((entry) =>
 			entry.key
@@ -628,9 +756,9 @@
 		);
 	}
 
-	function clearReadFromQueue(entries) {
+	function clearReadFromQueue(entries, keep) {
 		return (Array.isArray(entries) ? entries : []).filter(
-			(entry) => !entry.readAt,
+			(entry) => !entry.readAt || Boolean(keep?.has(entry.key)),
 		);
 	}
 
@@ -677,6 +805,28 @@
 
 	async function saveQueue(entries) {
 		await save(STORAGE.queue, entries);
+		return entries;
+	}
+
+	async function loadFavoriteEntries() {
+		const stored = await load(STORAGE.favorites, []);
+
+		return Array.isArray(stored) ? stored.filter((entry) => entry?.key) : [];
+	}
+
+	async function saveFavorites(entries) {
+		await save(STORAGE.favorites, entries);
+		return entries;
+	}
+
+	async function loadWatches() {
+		const stored = await load(STORAGE.watches, []);
+
+		return Array.isArray(stored) ? stored.filter((entry) => entry?.key) : [];
+	}
+
+	async function saveWatches(entries) {
+		await save(STORAGE.watches, entries);
 		return entries;
 	}
 
@@ -854,27 +1004,36 @@
 		return Boolean(getWriteBridge(sourceID)?.actions?.vote?.itemActions);
 	}
 
-	function itemActionLinksHTML(itemId, sourceID) {
+	function itemActionLinksHTML(itemId, sourceID, watchLink, about = {}) {
+		const between = watchLink ? `\n      |\n      ${watchLink}` : "";
+
 		if (!sourceHasItemActions(sourceID)) {
-			return "";
+			return between;
 		}
 
 		const id = escapeHTML(String(itemId));
 		const source = escapeHTML(String(sourceID || ""));
+		const meta =
+			` data-favorite-key="${escapeHTML(about.key || source + ":" + id)}"` +
+			` data-favorite-url="${escapeHTML(about.url || "")}"` +
+			` data-favorite-title="${escapeHTML(about.title || "")}"` +
+			` data-favorite-site="${escapeHTML(about.site || "")}"` +
+			` data-favorite-kind="${escapeHTML(about.kind || "discussion")}"` +
+			` data-favorite-parent="${escapeHTML(about.parent || "")}"`;
 
 		return `
       |
       <button class="item-action-link" type="button"
-      data-item-action="flag" data-item-action-source="${source}" data-item-action-id="${id}">flag</button>
+      data-item-action="flag" data-item-action-source="${source}" data-item-action-id="${id}">flag</button>${between}
       |
       <button class="item-action-link" type="button"
-      data-item-action="fave" data-item-action-source="${source}" data-item-action-id="${id}">favorite</button>`;
+      data-item-action="fave" data-item-action-source="${source}" data-item-action-id="${id}"${meta}>favorite</button>`;
 	}
 
 	const ITEM_ACTION_FIELD = { fave: "favorite", flag: "flagged" };
 
 	const ITEM_ACTION_LABEL = {
-		favorite: { on: "un-favorite", off: "favorite" },
+		favorite: { on: "unfavorite", off: "favorite" },
 		flagged: { on: "unflag", off: "flag" },
 	};
 
@@ -914,6 +1073,25 @@
 		seen.forEach(refreshItemActionControls);
 	}
 
+	function sourceSyncEnabled(settings, sourceID) {
+		const map = settings?.syncSources;
+
+		return Boolean(map && typeof map === "object" && map[sourceID]);
+	}
+
+	async function toggleFavorite(item, settings) {
+		const entries = await loadFavoriteEntries();
+		const on = entries.some((entry) => entry.key === item.key);
+
+		await saveFavorites(
+			on
+				? removeFromFavorites(entries, item.key)
+				: addToFavorites(entries, item, Date.now()),
+		);
+
+		return !on;
+	}
+
 	async function submitItemAction(button) {
 		const itemId = button.dataset.itemActionId;
 		const kind = button.dataset.itemAction;
@@ -923,18 +1101,30 @@
 			return;
 		}
 
+		const sourceID = button.dataset.itemActionSource;
 		const action = itemActionState(itemId)?.[field] ? "un" + kind : kind;
 
 		button.disabled = true;
 
 		try {
-			await openItemActionPopup(
-				button.dataset.itemActionSource,
-				itemId,
-				itemId,
-				action,
-				null,
-			);
+			if (kind === "fave") {
+				await toggleFavorite({
+					key: button.dataset.favoriteKey || `${sourceID}:${itemId}`,
+					url: button.dataset.favoriteUrl || "",
+					title: button.dataset.favoriteTitle || "",
+					site: button.dataset.favoriteSite || "",
+					kind: button.dataset.favoriteKind || "discussion",
+					source: sourceID,
+					id: itemId,
+					parent: button.dataset.favoriteParent || "",
+				});
+			}
+
+			const settings = await loadSettings();
+
+			if (kind !== "fave" || sourceSyncEnabled(settings, sourceID)) {
+				await openItemActionPopup(sourceID, itemId, itemId, action, null);
+			}
 		} finally {
 			button.disabled = false;
 			refreshItemActionControls(itemId);
@@ -2806,6 +2996,15 @@ ${
 	source.caveat
 		? `<div class="settings-option-hint">${escapeHTML(source.caveat)}${source.slow ? `<p class="settings-option-hint-slow">This source takes longer to fetch comments, so they may take a moment to appear.</p>` : ""}</div>`
 		: ""
+}${
+	sourceHasItemActions(source.id)
+		? `<div class="settings-suboptions" data-suboptions-of="source-${escapeHTML(source.id)}">
+<label class="settings-option sub-option">
+<input${idPrefix ? ` id="${escapeHTML(idPrefix + "sync-" + source.id)}"` : ""} data-source-sync="${escapeHTML(source.id)}" type="checkbox">
+<span>Also favourite and flag on ${escapeHTML(source.label)}</span>
+</label>
+</div>`
+		: ""
 }`,
 			)
 			.join("");
@@ -2823,7 +3022,12 @@ ${
 	}
 
 	// #region hnewhere-test-export
-	const HINTED_SETTINGS = new Set(["annotations", "pdfReader", "notepad"]);
+	const HINTED_SETTINGS = new Set([
+		"annotations",
+		"pdfReader",
+		"notepad",
+		"notifyOnWatch",
+	]);
 
 	function pdfViewerRefusesExtensions() {
 		return /firefox/i.test(navigator.userAgent || "");
@@ -2867,13 +3071,54 @@ ${
 		shortLabel: "HN",
 		caveat:
 			"Will send each page you visit to Algolia's Hacker News search, with no identifier attached. Vote, reply and submit through your existing HN session.",
-		capabilities: { vote: true, reply: true, submit: true },
+		capabilities: {
+			vote: true,
+			reply: true,
+			submit: true,
+			favorite: true,
+			flag: true,
+		},
 
 		profileURL: (author) =>
 			"https://news.ycombinator.com/user?id=" + encodeURIComponent(author),
 
 		async discover(url) {
 			return (await findHN(url)).map(algoliaDiscussion);
+		},
+
+		async probe(url, context) {
+			const target = normalizeURL(url);
+
+			if (!target) {
+				return null;
+			}
+
+			const since = Math.floor((context.since || 0) / 1000);
+			const filter = encodeURIComponent("created_at_i>" + since);
+			let total = 0;
+			let answered = false;
+
+			for (const query of [url, target]) {
+				const result = await request(
+					"https://hn.algolia.com/api/v1/search?tags=story&restrictSearchableAttributes=url&hitsPerPage=0&query=" +
+						encodeURIComponent(query) +
+						"&numericFilters=" +
+						filter,
+				);
+
+				if (!result || typeof result.nbHits !== "number") {
+					continue;
+				}
+
+				answered = true;
+				total = Math.max(total, result.nbHits);
+			}
+
+			if (!answered) {
+				return null;
+			}
+
+			return { mark: total, changed: total > 0 };
 		},
 
 		async frontPage() {
@@ -3027,6 +3272,35 @@ ${
 
 		profileURL: (author) =>
 			"https://www.reddit.com/user/" + encodeURIComponent(author) + "/",
+
+		async probe(url, context) {
+			if ((await redditTier()) !== "archive") {
+				return null;
+			}
+
+			const target = normalizeURL(url);
+
+			if (!target) {
+				return null;
+			}
+
+			const scheme = url.startsWith("http://") ? "http://" : "https://";
+			const result = await request(
+				"https://arctic-shift.photon-reddit.com/api/posts/search?limit=25&fields=id&url=" +
+					encodeURIComponent(scheme + target),
+			);
+
+			if (!result || !Array.isArray(result.data)) {
+				return null;
+			}
+
+			const mark = result.data
+				.map((post) => post.id)
+				.sort()
+				.join(",");
+
+			return { mark, changed: watchMarkChanged(context.mark, mark) };
+		},
 
 		async discover(url) {
 			const target = normalizeURL(url);
@@ -3211,6 +3485,29 @@ ${
 		capabilities: { vote: false, reply: false, submit: false },
 
 		profileURL: (handle) => "https://bsky.app/profile/" + encodeURIComponent(handle),
+
+		async probe(url, context) {
+			const target = bskyTarget(url);
+
+			if (!target) {
+				return null;
+			}
+
+			const counted = await bskyJSON(
+				`${CONSTELLATION}/links/count?target=${encodeURIComponent(target)}` +
+					"&collection=app.bsky.feed.post&path=.embed.external.uri",
+				{ "User-Agent": CONSTELLATION_UA },
+			);
+
+			if (!counted || typeof counted.total !== "number") {
+				return null;
+			}
+
+			return {
+				mark: counted.total,
+				changed: watchMarkChanged(context.mark, counted.total),
+			};
+		},
 
 		async discover(url) {
 			const target = bskyTarget(url);
@@ -4012,7 +4309,7 @@ button {
 			index.welded,
 		);
 
-		if (found.length !== 1) {
+		if (!found.length) {
 			return null;
 		}
 
@@ -4092,6 +4389,49 @@ button {
 		save.textContent = "save";
 
 		let warnedFor = null;
+		let dismissWhy = null;
+
+		const hideWhy = () => {
+			why.classList.remove("is-open");
+
+			if (dismissWhy) {
+				dismissWhy();
+				dismissWhy = null;
+			}
+		};
+
+		const showWhy = (text) => {
+			why.textContent = text;
+			why.classList.add("is-open");
+			hideWhyOnAway();
+		};
+
+		function hideWhyOnAway() {
+			if (dismissWhy) {
+				dismissWhy();
+			}
+
+			const root = editor.getRootNode();
+			const away = (event) => {
+				if (event.composedPath?.().includes(why)) {
+					return;
+				}
+
+				hideWhy();
+			};
+
+			const attach = () => {
+				root.addEventListener("pointerdown", away, true);
+				document.addEventListener("pointerdown", away, true);
+			};
+
+			dismissWhy = () => {
+				root.removeEventListener("pointerdown", away, true);
+				document.removeEventListener("pointerdown", away, true);
+			};
+
+			setTimeout(attach, 0);
+		}
 
 		const commit = () => {
 			const parsed = noteFromText(field.value);
@@ -4107,11 +4447,13 @@ button {
 				!canAnchor(parsed.exact)
 			) {
 				warnedFor = parsed.exact;
-				why.textContent =
-					"That passage is not in this document. Save again to keep it without a highlight.";
+				showWhy(
+					"Your quoted text wasn't found in this document. Press Save again to keep it without a highlight.",
+				);
 				return;
 			}
 
+			hideWhy();
 			onSave(parsed);
 		};
 
@@ -4127,7 +4469,11 @@ button {
 			}
 		};
 
-		row.append(save, cancel, why);
+		const saveWrap = document.createElement("span");
+
+		saveWrap.className = "note-editor-save-wrap";
+		saveWrap.append(save, why);
+		row.append(saveWrap, cancel);
 		editor.append(field, row);
 
 		return { editor, field };
@@ -4707,6 +5053,372 @@ button {
 				compareStoriesByDiscussion,
 			),
 		);
+	}
+
+	// -------------------------
+	// Watch list
+	// -------------------------
+
+	const WATCH_INTERVAL_MS = 3600000;
+	const WATCH_BATCH = 4;
+	const WATCH_POLL_DELAY_MS = 5000;
+
+	async function grantNotifications() {
+		if (typeof Notification === "undefined") {
+			return false;
+		}
+
+		if (Notification.permission === "granted") {
+			return true;
+		}
+
+		if (Notification.permission === "denied") {
+			return false;
+		}
+
+		try {
+			return (await Notification.requestPermission()) === "granted";
+		} catch (error) {
+			console.error("Backchannel notification permission failed:", error);
+
+			return false;
+		}
+	}
+
+	function notifyWatch(entry, count) {
+		const text =
+			pluralize(count, "discussion") +
+			" on " +
+			(entry.title || entry.site || entry.url);
+
+		if (typeof GM === "undefined" || typeof GM.notification !== "function") {
+			try {
+				if (
+					typeof Notification !== "undefined" &&
+					Notification.permission === "granted"
+				) {
+					new Notification("Backchannel", { body: text }).onclick = () => {
+						window.open(entry.url, "_blank");
+					};
+				}
+			} catch (error) {
+				console.error("Backchannel notification failed:", error);
+			}
+
+			return;
+		}
+
+		try {
+			GM.notification({
+				title: "Backchannel",
+				text:
+					pluralize(count, "discussion") +
+					" on " +
+					(entry.title || entry.site || entry.url),
+				timeout: 8000,
+				onclick: () => {
+					window.open(entry.url, "_blank");
+				},
+			});
+		} catch (error) {
+			console.error("Backchannel notification failed:", error);
+		}
+	}
+
+	function watchStory(entry, discussion) {
+		return {
+			id: discussion.id,
+			key: discussion.key,
+			source: discussion.source,
+			permalink: discussion.permalink || "",
+			url: discussion.articleURL || entry.url,
+			title: entry.title || discussion.title || "",
+			by: discussion.author || "",
+			score: discussion.score || 0,
+			time: discussion.createdAt || 0,
+			descendants: discussion.commentCount || 0,
+			site: entry.site || "",
+		};
+	}
+
+	async function probeWatch(entry, settings) {
+		const marks = { ...(entry.marks || {}) };
+		let changed = false;
+		let answered = false;
+
+		for (const source of enabledSources(settings)) {
+			if (typeof source.probe !== "function") {
+				continue;
+			}
+
+			let result = null;
+
+			try {
+				result = await source.probe(entry.url, {
+					mark: marks[source.id],
+					since: entry.addedAt,
+				});
+			} catch (error) {
+				console.error("Backchannel " + source.id + " probe failed:", error);
+			}
+
+			if (!result) {
+				continue;
+			}
+
+			answered = true;
+			marks[source.id] = result.mark;
+			changed = changed || result.changed;
+		}
+
+		return { marks, changed, answered };
+	}
+
+	async function pollWatches(settings) {
+		const entries = await loadWatches();
+		const due = watchesDue(entries, Date.now(), WATCH_INTERVAL_MS).slice(
+			0,
+			WATCH_BATCH,
+		);
+
+		if (!due.length) {
+			return false;
+		}
+
+		for (const entry of due) {
+			const { marks, changed, answered } = await probeWatch(entry, settings);
+			const now = Date.now();
+
+			entry.marks = marks;
+			entry.checkedAt = now;
+			entry.misses = answered ? 0 : (entry.misses || 0) + 1;
+
+			if (changed) {
+				const found = await discoverAll([entry.url], settings);
+
+				if (found.length) {
+					entry.foundAt = now;
+					entry.count = found.length;
+
+					const queued = await loadQueue();
+					const placeholder = queued.find(
+						(item) => queueKey(item) === entry.key,
+					);
+					const story = watchStory(entry, found[0]);
+
+					if (placeholder) {
+						Object.assign(placeholder, story, {
+							key: entry.key,
+							title: story.title || placeholder.title,
+							watchPlaceholder: false,
+							readAt: null,
+						});
+
+						await saveQueue(queued);
+					} else {
+						await saveQueue(addToQueue(queued, story, now));
+					}
+
+					if (settings.notifyOnWatch) {
+						notifyWatch(entry, found.length);
+					}
+				}
+			}
+		}
+
+		await saveWatches(entries);
+
+		return unseenWatchCount(entries) > 0;
+	}
+
+	async function refreshWatchSignal() {
+		if (!sidebarUI?.shadow) {
+			return;
+		}
+
+		await refreshQueueCount(sidebarUI.shadow);
+		await refreshNextUp(sidebarUI.shadow);
+	}
+
+	function watchQueueEntry(page, now) {
+		return {
+			id: page.key,
+			key: page.key,
+			source: "",
+			permalink: "",
+			url: page.url,
+			title: page.title || page.url,
+			by: "",
+			score: 0,
+			time: Math.floor(now / 1000),
+			descendants: 0,
+			site: page.site || "",
+			watchPlaceholder: true,
+		};
+	}
+
+	function watchQueueStory(page, discussions, now) {
+		if (!discussions?.length) {
+			return watchQueueEntry(page, now);
+		}
+
+		const total = discussions.reduce(
+			(sum, each) => sum + (each.commentCount || 0),
+			0,
+		);
+
+		const best = discussions.reduce((pick, each) =>
+			(each.score || 0) > (pick.score || 0) ||
+			((each.score || 0) === (pick.score || 0) &&
+				(each.commentCount || 0) > (pick.commentCount || 0))
+				? each
+				: pick,
+		);
+
+		return {
+			...watchStory(page, best),
+			key: page.key,
+			descendants: total,
+		};
+	}
+
+	async function startWatching(page, discussions) {
+		const now = Date.now();
+
+		await saveWatches(addToWatchList(await loadWatches(), page, now));
+
+		const queued = await loadQueue();
+
+		if (!queued.some((entry) => queueKey(entry) === page.key)) {
+			await saveQueue(
+				addToQueue(queued, watchQueueStory(page, discussions, now), now),
+			);
+		}
+	}
+
+	async function stopWatching(key) {
+		await saveWatches(removeFromWatchList(await loadWatches(), key));
+	}
+
+	function wireRowWatchLink(button, story, options) {
+		if (!button) {
+			return;
+		}
+
+		const url = story.url || "";
+		const key = normalizeURL(url);
+
+		if (!key) {
+			button.hidden = true;
+
+			return;
+		}
+
+		const paint = (on) => {
+			button.textContent = on ? "unwatch" : "watch";
+			button.classList.toggle("item-action-on", on);
+		};
+
+		paint(Boolean(options.watching));
+
+		if (!options.watching) {
+			loadWatches()
+				.then((entries) => paint(entries.some((entry) => entry.key === key)))
+				.catch(console.error);
+		}
+
+		button.onclick = async () => {
+			const entries = await loadWatches();
+			const on = entries.some((entry) => entry.key === key);
+
+			if (on) {
+				await stopWatching(key);
+			} else {
+				await startWatching({
+					key,
+					url,
+					title: story.title || "",
+					site: story.site || "",
+				});
+			}
+
+			paint(!on);
+
+			if (typeof options.reload === "function") {
+				await options.reload();
+			}
+
+			const root = button.getRootNode();
+
+			refreshQueueCount(root);
+			refreshNextUp(root);
+		};
+	}
+
+	function wireWatchToggle(button, title, discussions) {
+		if (!button) {
+			return;
+		}
+
+		const url = pageAddress();
+		const key = normalizeURL(url);
+
+		if (!key) {
+			button.hidden = true;
+
+			return;
+		}
+
+		const paint = (watching) => {
+			button.textContent = watching ? "unwatch" : "watch";
+			button.setAttribute("aria-pressed", watching ? "true" : "false");
+		};
+
+		loadWatches()
+			.then((entries) => paint(entries.some((entry) => entry.key === key)))
+			.catch(console.error);
+
+		button.onclick = async () => {
+			const entries = await loadWatches();
+			const watching = entries.some((entry) => entry.key === key);
+
+			if (watching) {
+				await stopWatching(key);
+			} else {
+				await startWatching(
+					{
+						key,
+						url,
+						title: title || document.title || "",
+						site: hostLabel(url),
+					},
+					discussions,
+				);
+			}
+
+			paint(!watching);
+
+			refreshWatchSignal().catch(console.error);
+		};
+	}
+
+	function scheduleWatchPoll(settings) {
+		const run = () => {
+			pollWatches(settings)
+				.then((found) => {
+					if (found) {
+						refreshWatchSignal().catch(console.error);
+					}
+				})
+				.catch(console.error);
+		};
+
+		if (typeof requestIdleCallback === "function") {
+			requestIdleCallback(run);
+			return;
+		}
+
+		setTimeout(run, WATCH_POLL_DELAY_MS);
 	}
 
 	const THREAD_CEILING_MS = 20000;
@@ -7790,7 +8502,7 @@ button {
 			return;
 		}
 
-		if (on && !frontPageAvailable && !queueHasItems) {
+		if (on && !frontPageAvailable && !queueHasItems && !notedHasItems) {
 			return;
 		}
 
@@ -7844,6 +8556,44 @@ button {
 		crossFadeCommentsView(comments, swap);
 	}
 
+	const BROWSE_TAB_ORDER = ["front", "queue", "collection"];
+
+	function slideBrowseList(ui, direction, render) {
+		const list = ui?.shadow?.querySelector("#browse-list");
+
+		if (!list || prefersReducedMotion()) {
+			render().catch(console.error);
+			return;
+		}
+
+		if (list._hnewhereSlideTimer) {
+			clearTimeout(list._hnewhereSlideTimer);
+		}
+
+		const out = direction > 0 ? "slide-out-left" : "slide-out-right";
+		const enter = direction > 0 ? "slide-in-right" : "slide-in-left";
+
+		list.classList.remove("slide-in-left", "slide-in-right");
+		list.classList.add(out);
+
+		list._hnewhereSlideTimer = window.setTimeout(async () => {
+			try {
+				await render();
+			} catch (error) {
+				console.error(error);
+			}
+
+			list.classList.remove(out);
+			list.classList.add(enter);
+
+			requestAnimationFrame(() => {
+				requestAnimationFrame(() => list.classList.remove(enter));
+			});
+
+			list._hnewhereSlideTimer = null;
+		}, VIEW_SWAP_FADE_MS);
+	}
+
 	function crossFadeCommentsView(comments, swap) {
 		if (comments._hnewhereSwapTimer) {
 			clearTimeout(comments._hnewhereSwapTimer);
@@ -7890,15 +8640,45 @@ button {
 		const commentTotal = `<a class="browse-comments-total" href="${escapeHTML(story.url)}"
 	title="Go to the page and read what was said about it">${totalComments}<span class="browse-comments-floor" aria-hidden="true">+</span> ${totalWord}</a>`;
 
-		const actions =
-			!story.source || getSource(story.source)?.capabilities?.vote
-				? itemActionLinksHTML(story.id, story.source || "hn")
-				: "";
+		const queueLink = options.watching
+			? ""
+			: `|
+	<button class="browse-save-link" type="button">queue</button>`;
 
-		const meta = `${escapeHTML(pluralize(story.score, "point"))}${story.by ? ` by ${escapeHTML(story.by)}` : ""}
+		const watchLink = options.watchable
+			? `<button class="item-action-link browse-watch-link" type="button">watch</button>`
+			: "";
+
+		const actions = options.unfavorite
+			? `${watchLink ? `\n      |\n      ${watchLink}` : ""}
+      |
+      <button class="item-action-link browse-unfavorite-link" type="button">unfavorite</button>`
+			: !story.source || getSource(story.source)?.capabilities?.vote
+				? itemActionLinksHTML(story.id, story.source || "hn", watchLink, {
+						key: `${story.source || "hn"}:${story.id}`,
+						url: story.url,
+						title: story.title,
+						site: story.site,
+						kind: "discussion",
+					})
+					: itemActionLinksHTML("", "", watchLink);
+
+		const meta = options.noted
+			? `${escapeHTML(pluralize(story.noteCount || 0, "note"))}
 	<span class="item-age">${escapeHTML(timeAgo(story.time))}</span>
-	|
-	<button class="browse-save-link" type="button">queue</button>
+	${queueLink}
+	${actions}`
+			: story.watchPlaceholder
+			? `<span class="item-age">watching since ${escapeHTML(timeAgo(story.time))}</span>
+	${queueLink}
+	${actions}`
+			: `${
+				story.score || story.by
+					? `${escapeHTML(pluralize(story.score || 0, "point"))}${story.by ? ` by ${escapeHTML(story.by)}` : ""}`
+					: ""
+			}
+	<span class="item-age">${escapeHTML(timeAgo(story.time))}</span>
+	${queueLink}
 	${actions}
 	|
 	${commentTotal}`;
@@ -7907,7 +8687,9 @@ button {
 		row.className = "story browse-row";
 		row.dataset.storyId = String(story.id);
 		row.innerHTML = `
-	<div class="browse-rank">${rank}.</div>
+	<div class="browse-rank">${
+		options.bullet ? (options.fresh ? "&#9679;" : "&#9675;") : `${rank}.`
+	}</div>
 	<div class="browse-main">
 	<div class="story-title">
 	<a class="browse-title-link" href="${escapeHTML(story.url)}">${escapeHTML(story.title)}</a>
@@ -7928,10 +8710,26 @@ button {
 			};
 		}
 
+		wireRowWatchLink(row.querySelector(".browse-watch-link"), story, options);
+
+		if (options.unfavorite) {
+			const drop = row.querySelector(".browse-unfavorite-link");
+
+			if (drop) {
+				drop.onclick = async () => {
+					await saveFavorites(
+						removeFromFavorites(await loadFavoriteEntries(), options.unfavorite),
+					);
+
+					await options.reload?.();
+				};
+			}
+		}
+
 		const saveButton = row.querySelector(".browse-save-link");
 
-		{
-			const queuedLabel = options.inQueue ? "remove" : "queued";
+		if (saveButton) {
+			const queuedLabel = options.inQueue ? "unqueue" : "queued";
 
 			const key = queueKey(story);
 
@@ -7972,6 +8770,7 @@ button {
 	}
 
 	let queueHasItems = false;
+	let notedHasItems = false;
 	let frontPageAvailable = true;
 
 	function browseLabel() {
@@ -8003,7 +8802,7 @@ button {
 		}
 
 		if (wordmark) {
-			wordmark.hidden = !frontPageAvailable && !queueHasItems;
+			wordmark.hidden = !frontPageAvailable && !queueHasItems && !notedHasItems;
 
 			if (!isBrowsing({ shadow: root })) {
 				wordmark.title = browseLabel();
@@ -8017,6 +8816,123 @@ button {
 				setBrowseMode(sidebarUI, false);
 			}
 		}
+	}
+
+	async function loadNotedIndex() {
+		return notedDocuments(await load(NOTES_INDEX_KEY, [])).sort(
+			(a, b) => (b.updated || 0) - (a.updated || 0),
+		);
+	}
+
+	async function refreshNotedCount(root) {
+		const tab = root?.querySelector?.("#browse-tab-collection");
+
+		if (!tab) {
+			return;
+		}
+
+		const [favorites, noted] = await Promise.all([
+			loadFavoriteEntries(),
+			loadNotedIndex(),
+		]);
+		const entries = favorites.length + noted.length;
+
+		notedHasItems = entries > 0;
+
+		if (notedHasItems) {
+			tab.textContent = "collection";
+			tab.style.setProperty("--collection-tab-width", tab.scrollWidth + "px");
+		}
+
+		tab.classList.toggle("is-collapsed", !notedHasItems);
+		tab.setAttribute("aria-hidden", String(!notedHasItems));
+		tab.tabIndex = notedHasItems ? 0 : -1;
+		tab.parentElement?.classList.toggle("has-collection", notedHasItems);
+
+		if (!notedHasItems && browseTab === "collection" && sidebarUI) {
+			renderBrowseView(sidebarUI, { tab: "front" }).catch(console.error);
+		}
+	}
+
+	function collectionRow(entry, list, rank, options = {}) {
+		return renderBrowseRow(
+			{
+				id: entry.key,
+				key: entry.key,
+				source: "",
+				permalink: "",
+				url: entry.url || "",
+				title: entry.title || entry.url || entry.id,
+				by: "",
+				score: 0,
+				time: Math.floor((entry.updated || entry.addedAt || Date.now()) / 1000),
+				descendants: entry.count || 0,
+				site: entry.url ? hostLabel(entry.url) : "",
+				noteCount: entry.count || 0,
+			},
+			list,
+			rank,
+			{
+				noted: Boolean(entry.count),
+				watchable: (entry.kind || "discussion") !== "comment",
+				...options,
+			},
+		);
+	}
+
+	async function renderCollectionView(ui, list) {
+		const [favorites, noted] = await Promise.all([
+			loadFavoriteEntries(),
+			loadNotedIndex(),
+		]);
+		const saved = favoritesOfKind(favorites, "discussion");
+		const comments = favoritesOfKind(favorites, "comment");
+
+		list.replaceChildren();
+
+		if (!favorites.length && !noted.length) {
+			const empty = document.createElement("div");
+			empty.className = "browse-empty";
+			empty.textContent =
+				"Nothing collected yet. Favourite a discussion, or write a note on any page, and it will be kept here.";
+			list.appendChild(empty);
+			return;
+		}
+
+		let rank = 0;
+		const reload = () => renderCollectionView(ui, list);
+
+		if (saved.length) {
+			subhead(list, "favourites");
+
+			for (const entry of saved) {
+				collectionRow(entry, list, (rank += 1), {
+					unfavorite: entry.key,
+					reload,
+				});
+			}
+		}
+
+		if (comments.length) {
+			subhead(list, "comments");
+
+			for (const entry of comments) {
+				collectionRow(entry, list, (rank += 1), {
+					unfavorite: entry.key,
+					reload,
+				});
+			}
+		}
+
+		if (noted.length) {
+			subhead(list, "noted");
+
+			for (const entry of noted) {
+				collectionRow(entry, list, (rank += 1), { reload });
+			}
+		}
+
+		refreshAllItemActionControls();
 	}
 
 	async function refreshQueueCount(root) {
@@ -8040,6 +8956,7 @@ button {
 		tab.classList.toggle("is-collapsed", !queueHasItems);
 		tab.setAttribute("aria-hidden", String(!queueHasItems));
 		tab.tabIndex = queueHasItems ? 0 : -1;
+		tab.parentElement?.classList.toggle("has-queue", queueHasItems);
 
 		const tabs = tab.parentElement;
 
@@ -8047,6 +8964,7 @@ button {
 			requestAnimationFrame(() => tabs.classList.add("is-ready"));
 		}
 
+		await refreshNotedCount(root);
 		await refreshBrowseAffordances(root);
 
 		if (!queueHasItems && browseTab === "queue" && sidebarUI) {
@@ -8341,8 +9259,18 @@ button {
 		return changed;
 	}
 
+	function subhead(list, text) {
+		const heading = document.createElement("div");
+
+		heading.className = "browse-subhead";
+		heading.textContent = text;
+		list.appendChild(heading);
+	}
+
 	async function renderQueueView(ui, list) {
 		const entries = sortQueue(await loadQueue());
+		const watching = await loadWatches();
+		const watched = new Map(watching.map((entry) => [entry.key, entry]));
 
 		list.replaceChildren();
 
@@ -8355,10 +9283,60 @@ button {
 			return;
 		}
 
-		entries.forEach((entry, index) => {
-			const row = renderBrowseRow(entry, list, index + 1, { inQueue: true });
+		const kept = sortWatchedEntries(
+			entries.filter((entry) => watched.has(queueKey(entry))),
+			(entry) => watched.get(queueKey(entry)),
+		);
+		const rest = entries.filter((entry) => !watched.has(queueKey(entry)));
+		const reload = () => renderQueueView(ui, list);
+		let rank = 0;
+
+		if (kept.length) {
+			subhead(list, "watching");
+		}
+
+		for (const entry of kept) {
+			const state = watched.get(queueKey(entry));
+			const fresh = watchIsFresh(state);
+			const row = renderBrowseRow(entry, list, 0, {
+				inQueue: true,
+				watchable: true,
+				watching: true,
+				bullet: true,
+				fresh,
+				reload,
+			});
+
+			row.classList.add("browse-row-watching");
 			row.classList.toggle("browse-row-read", Boolean(entry.readAt));
-		});
+			row.classList.toggle("browse-row-fresh", fresh);
+
+			if (fresh) {
+				const pill = document.createElement("span");
+
+				pill.className = "browse-unread-pill";
+				pill.textContent = "UNREAD";
+				row.querySelector(".story-title")?.appendChild(pill);
+			}
+			row.classList.toggle(
+				"browse-row-stalled",
+				Boolean(!state?.foundAt && state?.misses >= WATCH_MISS_CEILING),
+			);
+		}
+
+		if (kept.length && rest.length) {
+			subhead(list, "queued");
+		}
+
+		for (const entry of rest) {
+			const row = renderBrowseRow(entry, list, (rank += 1), {
+				inQueue: true,
+				watchable: true,
+				reload,
+			});
+
+			row.classList.toggle("browse-row-read", Boolean(entry.readAt));
+		}
 
 		refreshAllItemActionControls();
 
@@ -8368,13 +9346,16 @@ button {
 			}
 		});
 
-		if (entries.some((entry) => entry.readAt)) {
+		if (entries.some((entry) => entry.readAt && !watched.has(queueKey(entry)))) {
 			const clear = document.createElement("button");
 			clear.type = "button";
 			clear.className = "browse-nav-link browse-clear-read";
 			clear.textContent = "clear read";
 			clear.onclick = async () => {
-				await saveQueue(clearReadFromQueue(await loadQueue()));
+				const keep = new Set((await loadWatches()).map((entry) => entry.key));
+
+				await saveQueue(clearReadFromQueue(await loadQueue(), keep));
+
 				await renderQueueView(ui, list);
 				refreshQueueCount(ui.shadow);
 				refreshNextUp(ui.shadow);
@@ -8463,8 +9444,7 @@ button {
 		}
 
 		for (const tab of ui.shadow.querySelectorAll(".browse-tab")) {
-			const isCurrent =
-				tab.id === (browseTab === "queue" ? "browse-tab-queue" : "browse-tab-front");
+			const isCurrent = tab.id === "browse-tab-" + (browseTab || "front");
 			tab.classList.toggle("is-current", isCurrent);
 			tab.setAttribute("aria-selected", String(isCurrent));
 		}
@@ -8472,7 +9452,7 @@ button {
 		if (sidebarHasDiscussion) {
 			setWordmarkLocation(ui, "Discussion", { elsewhere: true });
 		} else {
-			setWordmarkLocation(ui, browseTab === "queue" ? "Queue" : "");
+			setWordmarkLocation(ui, "");
 		}
 
 		await refreshSubmitAffordance(ui.shadow);
@@ -8482,6 +9462,12 @@ button {
 		if (browseTab === "queue") {
 			setBlendNote(ui, []);
 			await renderQueueView(ui, list);
+			return;
+		}
+
+		if (browseTab === "collection") {
+			setBlendNote(ui, []);
+			await renderCollectionView(ui, list);
 			return;
 		}
 
@@ -9339,18 +10325,123 @@ header {
 	opacity:0;
 }
 
+#browse-list {
+	transition:opacity .16s ease, transform .16s ease;
+}
+
+#browse-list.slide-out-left {
+	opacity:0;
+	transform:translateX(-14px);
+}
+
+#browse-list.slide-out-right {
+	opacity:0;
+	transform:translateX(14px);
+}
+
+#browse-list.slide-in-right,
+#browse-list.slide-in-left {
+	transition:none;
+	opacity:0;
+}
+
+#browse-list.slide-in-right {
+	transform:translateX(14px);
+}
+
+#browse-list.slide-in-left {
+	transform:translateX(-14px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	#browse-list {
+		transition:none;
+	}
+}
+
 .browse-tabs {
 	display:flex;
 	align-items:baseline;
-	margin:0 0 10px var(--browse-indent);
+	margin:0 0 10px 8px;
 	font-family:Verdana, Geneva, sans-serif;
-	font-size:11px;
+	font-size:13px;
 }
 
+.browse-subhead {
+	margin:0 0 6px;
+	padding-left:8px;
+	color:var(--meta);
+	font-size:11px;
+	font-family:Verdana, Geneva, sans-serif;
+}
+
+.browse-row + .browse-subhead {
+	margin-top:14px;
+	padding-top:14px;
+	border-top:1px solid var(--surface-divider);
+}
+
+
+.browse-row-watching .browse-rank {
+	color:var(--accent);
+}
+
+.browse-unread-pill {
+	margin-left:.5em;
+	padding:0 4px;
+	border-radius:3px;
+	background:var(--active-tint);
+	color:var(--muted);
+	font-size:9px;
+	font-weight:600;
+	letter-spacing:.04em;
+	vertical-align:1px;
+}
+
+.browse-row-stalled .story-title::before {
+	opacity:.3;
+}
+
+.browse-row-stalled .story-title a {
+	opacity:.55;
+}
+
+#browse-tab-front::after,
 #browse-tab-queue::after {
-	content:"|";
+	content:none;
 	margin:0 .35em;
 	color:var(--meta);
+}
+
+.browse-tabs.has-queue #browse-tab-front::after {
+	content:"|";
+}
+
+#browse-tab-collection {
+	margin-left:auto;
+}
+
+#browse-tab-collection {
+	max-width:var(--collection-tab-width, 8em);
+	overflow:hidden;
+	white-space:nowrap;
+	opacity:1;
+}
+
+#browse-tab-collection.is-collapsed {
+	max-width:0;
+	opacity:0;
+	pointer-events:none;
+}
+
+.browse-tabs.is-ready #browse-tab-collection {
+	transition:max-width .18s ease, opacity .18s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.browse-tabs.is-ready #browse-tab-collection {
+		transition:none;
+	}
 }
 
 #browse-tab-queue {
@@ -9438,7 +10529,7 @@ header {
 }
 
 .browse-blend-note {
-	margin:-7px 0 10px var(--browse-indent);
+	margin:-7px 0 10px 8px;
 	color:var(--meta);
 	font-size:11px;
 	font-family:Verdana, Geneva, sans-serif;
@@ -9820,6 +10911,40 @@ header button svg {
 	flex:1 1 auto;
 }
 
+.settings-option-byline {
+	display:flex;
+	align-items:baseline;
+	gap:.35em;
+	margin:3px 0 8px 21px;
+	color:var(--muted);
+	font-size:11px;
+	line-height:1.35;
+}
+
+.settings-byline-sep {
+	color:var(--muted);
+	opacity:.6;
+}
+
+.settings-byline-action {
+	padding:0;
+	border:0;
+	background:none;
+	color:var(--muted);
+	font:inherit;
+	font-size:11px;
+	text-decoration:underline dotted;
+	text-underline-offset:2px;
+	text-decoration-color:var(--border);
+	cursor:pointer;
+}
+
+@media (hover: hover) {
+	.settings-byline-action:hover {
+		color:var(--text);
+	}
+}
+
 .settings-inline-action {
 	flex:0 0 auto;
 	max-width:0;
@@ -9919,7 +11044,8 @@ header button svg {
 	margin-top:8px;
 }
 
-.page-header-disclosure {
+.page-header-disclosure,
+.page-header-watch {
 	font:inherit;
 	color:inherit;
 	background:none;
@@ -9929,6 +11055,11 @@ header button svg {
 	text-decoration:underline dotted;
 	text-underline-offset:2px;
 	text-decoration-color:var(--border);
+}
+
+.page-header-sep {
+	margin:0 .35em;
+	color:var(--meta);
 }
 
 .page-header-disclosure[aria-expanded="true"] {
@@ -10891,16 +12022,25 @@ The default PDF reader will be replaced with
 to allow highlighting and annotation directly onto PDFs.
 </div>
 </div>
-<div class="settings-option-row">
 <label class="settings-option">
 <input id="setting-notepad" data-setting="notepad" type="checkbox">
 <span>Enable notepad</span>
 </label>
-<button id="settings-notes-export" class="settings-inline-action" type="button">export</button>
-</div>
 <div class="settings-option-hint">
 Write your own notes on any article or PDF, with support for annotation.
 All stored locally.
+</div>
+<div class="settings-option-byline">
+<span id="settings-notes-count">0 notes</span>
+<span class="settings-byline-sep">|</span>
+<button id="settings-notes-export" class="settings-byline-action" type="button">export</button>
+</div>
+<label class="settings-option">
+<input id="setting-notify-on-watch" data-setting="notifyOnWatch" type="checkbox">
+<span>Notify me when a watched discussion has something new</span>
+</label>
+<div class="settings-option-hint">
+Sends a desktop notification the moment a watched page has a discussion worth reading.
 </div>
 </div>
 
@@ -10930,7 +12070,7 @@ All stored locally.
 </span>
 <button type="button" class="stepper-button" data-size-step="1" aria-label="Larger button">+</button>
 </div>
-<button id="settings-reset-button" class="settings-reset" type="button">Reset</button>
+<button id="settings-reset-button" class="settings-reset" type="button">reset</button>
 </div>
 <div class="button-preview">
 <div class="button-preview-stage">
@@ -11049,6 +12189,7 @@ ${[
 				"#setting-hide-without-discussion",
 			),
 			showButtonWithQueue: shadow.querySelector("#setting-show-button-with-queue"),
+			notifyOnWatch: shadow.querySelector("#setting-notify-on-watch"),
 			annotations: shadow.querySelector("#setting-annotations"),
 			annotationsWhenSidebarClosed: shadow.querySelector(
 				"#setting-annotations-closed",
@@ -11182,6 +12323,14 @@ ${[
 				}
 			}
 
+			for (const input of settingsPanel.querySelectorAll(
+				"input[data-source-sync]",
+			)) {
+				input.checked = Boolean(
+					(settings.syncSources || {})[input.dataset.sourceSync],
+				);
+			}
+
 			for (const [key, inputs] of Object.entries(settingsRadios)) {
 				for (const input of inputs) {
 					input.checked = input.value === settings[key];
@@ -11200,6 +12349,17 @@ ${[
 			)) {
 				input.checked = Boolean(sourceState[input.dataset.source]);
 				syncSourceHint(input);
+			}
+
+			for (const group of settingsPanel.querySelectorAll(
+				'[data-suboptions-of^="source-"]',
+			)) {
+				const id = group.dataset.suboptionsOf.slice("source-".length);
+				const on = settingsPanel.querySelector(
+					`input[data-source="${CSS.escape(id)}"]`,
+				)?.checked;
+
+				group.classList.toggle("is-visible", Boolean(on));
 			}
 
 			for (const group of suboptionGroups) {
@@ -11242,6 +12402,7 @@ ${[
 
 			if (open) {
 				setHideMenuOpen(false);
+				refreshNotesCount?.().catch(console.error);
 			}
 
 			if (open) {
@@ -11323,6 +12484,22 @@ ${[
 		}
 
 		const notesExport = shadow.querySelector("#settings-notes-export");
+		const notesCount = shadow.querySelector("#settings-notes-count");
+
+		const refreshNotesCount = async () => {
+			if (!notesCount) {
+				return;
+			}
+
+			const total = notedDocuments(await load(NOTES_INDEX_KEY, [])).reduce(
+				(sum, entry) => sum + (entry.count || 0),
+				0,
+			);
+
+			notesCount.textContent = pluralize(total, "note");
+		};
+
+		refreshNotesCount().catch(console.error);
 
 		if (notesExport) {
 			notesExport.onclick = (event) => {
@@ -11366,10 +12543,31 @@ ${[
 		});
 
 		settingsPanel.addEventListener("change", async (event) => {
+			const syncInput = event.target.closest("input[data-source-sync]");
+
+			if (syncInput) {
+				const current = await loadSettings();
+
+				await saveSettings({
+					syncSources: {
+						...(current.syncSources || {}),
+						[syncInput.dataset.sourceSync]: syncInput.checked,
+					},
+				});
+
+				return;
+			}
+
 			const sourceInput = event.target.closest("input[data-source]");
 
 			if (sourceInput) {
 				syncSourceHint(sourceInput);
+
+				settingsPanel
+					.querySelector(
+						`[data-suboptions-of="source-${CSS.escape(sourceInput.dataset.source)}"]`,
+					)
+					?.classList.toggle("is-visible", sourceInput.checked);
 
 				const current = await loadSettings();
 
@@ -11401,6 +12599,15 @@ ${[
 			settlePanesHeight();
 
 			const setting = input.dataset.setting;
+
+			if (setting === "notifyOnWatch") {
+				if (input.checked && !(await grantNotifications())) {
+					applySettingsPanelState(await saveSettings({ notifyOnWatch: false }));
+					settlePanesHeight();
+				}
+
+				return;
+			}
 
 			if (setting === "theme") {
 				refreshThemeSurfaces();
@@ -12035,6 +13242,18 @@ ${SUBMIT_FORM_CSS}
 	cursor:pointer;
 }
 
+.notepad-toggle[hidden] {
+	display:none;
+}
+
+.notepad-toggle::before {
+	content:"|";
+	margin:0 .35em;
+	color:var(--meta);
+	text-decoration:none;
+	display:inline-block;
+}
+
 .notepad-body {
 	overflow:hidden;
 	transition:max-height .22s ease, opacity .18s ease;
@@ -12057,10 +13276,6 @@ ${SUBMIT_FORM_CSS}
 
 .notepad-section.is-collapsed .notepad-body {
 	opacity:0;
-}
-
-.notepad-section.is-collapsed .notepad-rule-close {
-	display:none;
 }
 
 .note-editor {
@@ -12088,9 +13303,66 @@ ${SUBMIT_FORM_CSS}
 	margin-top:6px;
 }
 
+.note-editor-save-wrap {
+	position:relative;
+	display:inline-flex;
+}
+
 .note-editor-why {
-	color:var(--meta);
+	position:absolute;
+	top:calc(100% + 9px);
+	left:0;
+	z-index:5;
+	width:max-content;
+	max-width:min(280px, 72vw);
+	padding:7px 9px;
+	border:1px solid var(--surface-border);
+	border-radius:6px;
+	background:var(--surface);
+	color:var(--surface-text);
+	box-shadow:0 6px 18px rgba(0,0,0,.18);
 	font-size:11px;
+	line-height:1.4;
+	text-align:left;
+	opacity:0;
+	visibility:hidden;
+	pointer-events:none;
+	transform:translateY(-3px);
+	transition:opacity .12s ease, transform .12s ease, visibility .12s;
+}
+
+.note-editor-why::before,
+.note-editor-why::after {
+	content:"";
+	position:absolute;
+	left:11px;
+	width:0;
+	height:0;
+	border-left:6px solid transparent;
+	border-right:6px solid transparent;
+}
+
+.note-editor-why::before {
+	bottom:100%;
+	border-bottom:6px solid var(--surface-border);
+}
+
+.note-editor-why::after {
+	bottom:calc(100% - 1px);
+	border-bottom:6px solid var(--surface);
+}
+
+.note-editor-why.is-open {
+	opacity:1;
+	visibility:visible;
+	transform:translateY(0);
+	pointer-events:auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.note-editor-why {
+		transition:none;
+	}
 }
 
 .note-editor-cancel {
@@ -12727,8 +13999,9 @@ ${settingsPanelHTML()}
 <div id="comments-content">Loading...</div>
 <div id="browse-view" class="browse-view">
 <div class="browse-tabs" role="tablist">
-<button id="browse-tab-queue" class="browse-tab is-collapsed" type="button" role="tab" aria-hidden="true" tabindex="-1">queue</button>
 <button id="browse-tab-front" class="browse-tab is-current" type="button" role="tab">front pages</button>
+<button id="browse-tab-queue" class="browse-tab is-collapsed" type="button" role="tab" aria-hidden="true" tabindex="-1">queue</button>
+<button id="browse-tab-collection" class="browse-tab is-collapsed" type="button" role="tab" aria-hidden="true" tabindex="-1">collection</button>
 </div>
 <div id="browse-blend-note" class="browse-blend-note" hidden></div>
 <div id="browse-list"></div>
@@ -12963,13 +14236,23 @@ ${settingsPanelHTML()}
 		for (const [id, tab] of [
 			["#browse-tab-front", "front"],
 			["#browse-tab-queue", "queue"],
+			["#browse-tab-collection", "collection"],
 		]) {
 			const button = shadow.querySelector(id);
 
 			if (button) {
 				button.onclick = () => {
+					const from = BROWSE_TAB_ORDER.indexOf(browseTab || "front");
+					const to = BROWSE_TAB_ORDER.indexOf(tab);
+
+					if (from === to) {
+						return;
+					}
+
 					scrollBrowseToTop(ui);
-					renderBrowseView(ui, { tab }).catch(console.error);
+					slideBrowseList(ui, to > from ? 1 : -1, () =>
+						renderBrowseView(ui, { tab }),
+					);
 				};
 			}
 		}
@@ -13010,6 +14293,9 @@ ${settingsPanelHTML()}
 		const storyID = String(story.id);
 		const hnURL = discussionURL(story);
 		const title = options.title ?? story.title;
+		const watchLink = options.watchable
+			? `<button class="item-action-link browse-watch-link" type="button">watch</button>`
+			: "";
 
 		const showActions = options.actions !== false;
 		const showTitle = options.showTitle !== false;
@@ -13067,7 +14353,7 @@ ${settingsPanelHTML()}
 	}${
 		ageLabel ? escapeHTML(ageLabel) + " " : ""
 	}<span class="item-age" data-age-id="${escapeHTML(storyID)}">${timeAgo(storyCreatedAt)}</span><span class="story-vote-status" data-vote-status-id="${escapeHTML(storyID)}"></span>
-	${showActions ? itemActionLinksHTML(storyID, story.source || "hn") : ""}
+	${showActions ? itemActionLinksHTML(storyID, story.source || "hn", watchLink) : itemActionLinksHTML("", "", watchLink)}
 	${
 		showTitle || !hnURL
 			? ""
@@ -13104,6 +14390,16 @@ ${settingsPanelHTML()}
 		storyElement.dataset.storyId = storyID;
 
 		wrapLooseCommentText(storyElement.querySelector(".story-text"));
+
+		if (options.watchable) {
+			const address = pageAddress();
+
+			wireRowWatchLink(
+				storyElement.querySelector(".browse-watch-link"),
+				{ url: address, title: story.title || "", site: hostLabel(address) },
+				{},
+			);
+		}
 
 		container.appendChild(storyElement);
 
@@ -13881,7 +15177,18 @@ ${settingsPanelHTML()}
 
       ${isLocalSource ? "" : `<a class="focus-link" href="#">focus</a>`}
 		${isLocalSource ? `<a class="edit-note-link" href="#">edit</a> | <a class="delete-note-link" href="#">delete</a>` : ""}
-		${capabilities.vote ? itemActionLinksHTML(commentID, comment.source || "hn") : ""}
+		${
+			capabilities.vote
+				? itemActionLinksHTML(commentID, comment.source || "hn", "", {
+						key: `${comment.source || "hn"}:${commentID}`,
+						url: discussionURL(comment) || "",
+						title: comment.by ? `comment by ${comment.by}` : "comment",
+						site: "",
+						kind: "comment",
+						parent: String(comment.storyID || ""),
+					})
+				: ""
+		}
 
       <span class="toggle">
       [–]
@@ -14235,6 +15542,7 @@ ${settingsPanelHTML()}
 				compose: canReply,
 				title: resolved,
 				showTitle: true,
+				watchable: !disambiguating,
 			});
 
 			if (block) {
@@ -14265,7 +15573,14 @@ ${settingsPanelHTML()}
 				onAdd: () => startNotepadDraft(held.section, held.body),
 			});
 
-			ui.body.insertBefore(held.section, ui.body.querySelector(".page-sort"));
+			const composer =
+				stories.length === 1 ? ui.body.querySelector(".comment-composer") : null;
+
+			if (composer?.parentNode) {
+				composer.parentNode.insertBefore(held.section, composer);
+			} else {
+				ui.body.insertBefore(held.section, ui.body.querySelector(".page-sort"));
+			}
 
 			if (notesDiscussion) {
 				const thread = notesThread(notesDiscussion);
@@ -14520,6 +15835,15 @@ ${settingsPanelHTML()}
 					: "";
 			toggle.textContent = collapsed ? "show" : "hide";
 			toggle.setAttribute("aria-expanded", collapsed ? "false" : "true");
+			body.style.overflow = "hidden";
+
+			if (!collapsed) {
+				window.setTimeout(() => {
+					if (!section.classList.contains("is-collapsed")) {
+						body.style.overflow = "visible";
+					}
+				}, 240);
+			}
 		};
 
 		add.type = "button";
@@ -14537,11 +15861,19 @@ ${settingsPanelHTML()}
 			body,
 
 			settle() {
-				if (!section.classList.contains("is-collapsed")) {
-					body.style.maxHeight = body.scrollHeight
-						? `${body.scrollHeight}px`
-						: "";
+				if (section.classList.contains("is-collapsed")) {
+					return;
 				}
+
+				body.style.maxHeight = body.scrollHeight
+					? `${body.scrollHeight}px`
+					: "";
+
+				window.setTimeout(() => {
+					if (!section.classList.contains("is-collapsed")) {
+						body.style.overflow = "visible";
+					}
+				}, 240);
 			},
 		};
 	}
@@ -14657,9 +15989,9 @@ ${settingsPanelHTML()}
 <div class="page-header-title">${single ? "" : escapeHTML(page)}</div>
 <div class="page-header-meta">${
 	stories.length > 1
-		? `<span class="page-header-total">${escapeHTML(pluralize(total, "comment"))}</span> across <button type="button" class="page-header-disclosure" aria-expanded="false" aria-controls="source-strip">${escapeHTML(pluralize(stories.length, "discussion"))}</button>`
+		? `<span class="page-header-total">${escapeHTML(pluralize(total, "comment"))}</span> across <button type="button" class="page-header-disclosure" aria-expanded="false" aria-controls="source-strip">${escapeHTML(pluralize(stories.length, "discussion"))}</button><span class="page-header-sep">|</span>`
 		: ""
-}</div>
+}<button type="button" class="page-header-watch" aria-pressed="false">watch discussion</button></div>
 <div class="source-strip${stories.length > 1 ? "" : " source-strip-single"}" id="source-strip">
 ${
 	stories
@@ -14677,6 +16009,8 @@ title="Show only this discussion">
 </div>`;
 
 		const strip = wrapper.querySelector(".source-strip");
+		wireWatchToggle(wrapper.querySelector(".page-header-watch"), page, stories);
+
 		const disclosure = wrapper.querySelector(".page-header-disclosure");
 
 		if (!disclosure) {
@@ -19673,6 +21007,8 @@ title="Show only this discussion">
 		}
 
 		const found = await discoverAll(pageAddresses(), settings);
+
+		scheduleWatchPoll(settings);
 
 		const recoverable = arrivedFromClick && (!last.source || last.source === "hn");
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -8818,7 +8818,7 @@ button {
 			const empty = document.createElement("div");
 			empty.className = "browse-empty";
 			empty.textContent =
-				"Nothing collected yet. Favourite a discussion, or write a note on any page, and it will be kept here.";
+				"Nothing collected yet. Favorite a discussion, or write a note on any page, and it will be kept here.";
 			list.appendChild(empty);
 			return;
 		}
@@ -8827,7 +8827,7 @@ button {
 		const reload = () => renderCollectionView(ui, list);
 
 		if (saved.length) {
-			subhead(list, "favourites");
+			subhead(list, "favorite discussions");
 
 			for (const entry of saved) {
 				collectionRow(entry, list, (rank += 1), {
@@ -8838,7 +8838,7 @@ button {
 		}
 
 		if (comments.length) {
-			subhead(list, "comments");
+			subhead(list, "favorite comments");
 
 			for (const entry of comments) {
 				collectionRow(entry, list, null, {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -197,7 +197,6 @@
 		blocked: "HNewhere:blocked_sites",
 		queue: "HNewhere:queue",
 		favorites: "HNewhere:favorites",
-		itemActions: "HNewhere:item_actions",
 		watches: "HNewhere:watches",
 	};
 
@@ -895,8 +894,6 @@
 
 	let rememberedVotes = {};
 
-	let rememberedItemActions = {};
-
 	async function loadRememberedVotes() {
 		const stored = await load(STORAGE.votes, {});
 		const now = Date.now();
@@ -925,88 +922,12 @@
 		}
 	}
 
-	async function loadRememberedItemActions() {
-		const stored = await load(STORAGE.itemActions, {});
-		const now = Date.now();
-		const kept = {};
-		let expired = 0;
-
-		if (stored && typeof stored === "object" && !Array.isArray(stored)) {
-			for (const [itemId, record] of Object.entries(stored)) {
-				if (!record || typeof record !== "object") {
-					continue;
-				}
-
-				if (Number.isFinite(record.at) && now - record.at > VOTE_MEMORY_TTL) {
-					expired++;
-					continue;
-				}
-
-				kept[itemId] = record;
-			}
-		}
-
-		rememberedItemActions = kept;
-
-		if (expired) {
-			await save(STORAGE.itemActions, kept);
-		}
-	}
-
-	function rememberItemAction(itemId, patch) {
-		const key = String(itemId);
-		const next = { ...(rememberedItemActions[key] || {}), ...patch, at: Date.now() };
-
-		rememberedItemActions[key] = next;
-		save(STORAGE.itemActions, rememberedItemActions).catch(console.error);
-
-		return next;
-	}
-
-	function itemActionState(itemId) {
-		return rememberedItemActions[String(itemId)] || null;
-	}
-
-	const ITEM_ACTION_ACCOUNT_KEY = "account";
-
-	function rememberItemActionUnavailable(field) {
-		const account = rememberedItemActions[ITEM_ACTION_ACCOUNT_KEY] || {};
-
-		rememberedItemActions[ITEM_ACTION_ACCOUNT_KEY] = {
-			...account,
-			[field + "Unavailable"]: true,
-			at: Date.now(),
-		};
-
-		save(STORAGE.itemActions, rememberedItemActions).catch(console.error);
-	}
-
-	function clearItemActionUnavailable(field) {
-		const account = rememberedItemActions[ITEM_ACTION_ACCOUNT_KEY];
-
-		if (!account?.[field + "Unavailable"]) {
-			return;
-		}
-
-		delete account[field + "Unavailable"];
-		save(STORAGE.itemActions, rememberedItemActions).catch(console.error);
-		refreshAllItemActionControls();
-	}
-
-	function itemActionUnavailable(field) {
-		return Boolean(
-			rememberedItemActions[ITEM_ACTION_ACCOUNT_KEY]?.[field + "Unavailable"],
-		);
-	}
-
-	function sourceHasItemActions(sourceID) {
-		return Boolean(getWriteBridge(sourceID)?.actions?.vote?.itemActions);
-	}
+	// #region hnewhere-test-export
 
 	function itemActionLinksHTML(itemId, sourceID, watchLink, about = {}) {
 		const between = watchLink ? `\n      |\n      ${watchLink}` : "";
 
-		if (!sourceHasItemActions(sourceID)) {
+		if (!itemId) {
 			return between;
 		}
 
@@ -1026,46 +947,31 @@
       data-item-action="fave" data-item-action-source="${source}" data-item-action-id="${id}"${meta}>favorite</button>`;
 	}
 
-	const ITEM_ACTION_FIELD = { fave: "favorite" };
+	function favoriteKeysOf(entries) {
+		return new Set(
+			(Array.isArray(entries) ? entries : [])
+				.map((entry) => entry?.key)
+				.filter(Boolean),
+		);
+	}
 
-	const ITEM_ACTION_LABEL = {
-		favorite: { on: "unfavorite", off: "favorite" },
-	};
+	function paintFavoriteControls(root, keys) {
+		for (const button of root.querySelectorAll(`[data-item-action="fave"]`)) {
+			const on = keys.has(button.dataset.favoriteKey);
 
-	function refreshItemActionControls(itemId) {
-		const root = sidebarUI?.shadow;
-
-		if (!root) {
-			return;
-		}
-
-		const state = itemActionState(itemId) || {};
-		const selector = `[data-item-action-id="${CSS.escape(String(itemId))}"]`;
-
-		for (const button of root.querySelectorAll(selector)) {
-			const field = ITEM_ACTION_FIELD[button.dataset.itemAction];
-			const on = Boolean(state[field]);
-
-			button.hidden = itemActionUnavailable(field);
-			button.textContent = ITEM_ACTION_LABEL[field][on ? "on" : "off"];
+			button.textContent = on ? "unfavorite" : "favorite";
 			button.classList.toggle("item-action-on", on);
 		}
 	}
 
-	function refreshAllItemActionControls() {
+	// #endregion hnewhere-test-export
+
+	async function refreshFavoriteControls() {
 		const root = sidebarUI?.shadow;
 
-		if (!root) {
-			return;
+		if (root) {
+			paintFavoriteControls(root, favoriteKeysOf(await loadFavoriteEntries()));
 		}
-
-		const seen = new Set();
-
-		for (const button of root.querySelectorAll("[data-item-action-id]")) {
-			seen.add(button.dataset.itemActionId);
-		}
-
-		seen.forEach(refreshItemActionControls);
 	}
 
 	async function toggleFavorite(item, settings) {
@@ -1083,14 +989,11 @@
 
 	async function submitItemAction(button) {
 		const itemId = button.dataset.itemActionId;
-		const kind = button.dataset.itemAction;
-		const field = ITEM_ACTION_FIELD[kind];
+		const sourceID = button.dataset.itemActionSource;
 
-		if (!itemId || !field || button.disabled) {
+		if (!itemId || button.dataset.itemAction !== "fave" || button.disabled) {
 			return;
 		}
-
-		const sourceID = button.dataset.itemActionSource;
 
 		button.disabled = true;
 
@@ -1107,7 +1010,8 @@
 			});
 		} finally {
 			button.disabled = false;
-			refreshItemActionControls(itemId);
+			await refreshFavoriteControls();
+			refreshNotedCount(sidebarUI?.shadow).catch(console.error);
 		}
 	}
 
@@ -7894,24 +7798,6 @@ button {
 				);
 			}
 
-			if (data.itemId && ITEM_ACTION_PATHS[data.action]) {
-				const field = "favorite";
-
-				if (data.reason === "action-unavailable") {
-					rememberItemActionUnavailable(field);
-					refreshAllItemActionControls();
-					return;
-				}
-
-				if (typeof data.applied === "boolean") {
-					rememberItemAction(data.itemId, { [field]: data.applied });
-
-					clearItemActionUnavailable(field);
-				}
-
-				refreshItemActionControls(data.itemId);
-			}
-
 			const pending = itemActionRequests.get(data.nonce);
 
 			if (!pending) {
@@ -8201,13 +8087,7 @@ button {
 		}
 	}
 
-	function hydrateItemActionsForRoot() {
-		refreshAllItemActionControls();
-	}
-
 	function hydrateVoteControlsForStory(storyID, voteLinks = new Map()) {
-		hydrateItemActionsForRoot();
-
 		const containers = sidebarUI?.body?.querySelectorAll(
 			`[data-hn-vote-story-id="${String(storyID)}"]`,
 		);
@@ -8609,15 +8489,13 @@ button {
 			? `${watchLink ? `\n      |\n      ${watchLink}` : ""}
       |
       <button class="item-action-link browse-unfavorite-link" type="button">unfavorite</button>`
-			: !story.source || getSource(story.source)?.capabilities?.vote
-				? itemActionLinksHTML(story.id, story.source || "hn", watchLink, {
-						key: `${story.source || "hn"}:${story.id}`,
-						url: story.url,
-						title: story.title,
-						site: story.site,
-						kind: "discussion",
-					})
-					: itemActionLinksHTML("", "", watchLink);
+			: itemActionLinksHTML(story.id, story.source || "hn", watchLink, {
+					key: `${story.source || "hn"}:${story.id}`,
+					url: story.url,
+					title: story.title,
+					site: story.site,
+					kind: "discussion",
+				});
 
 		const meta = options.noted
 			? `${escapeHTML(pluralize(story.noteCount || 0, "note"))}
@@ -8888,7 +8766,7 @@ button {
 			}
 		}
 
-		refreshAllItemActionControls();
+		refreshFavoriteControls().catch(console.error);
 	}
 
 	async function refreshQueueCount(root) {
@@ -9294,7 +9172,7 @@ button {
 			row.classList.toggle("browse-row-read", Boolean(entry.readAt));
 		}
 
-		refreshAllItemActionControls();
+		refreshFavoriteControls().catch(console.error);
 
 		refreshQueueEntries(entries).then((refreshed) => {
 			if (refreshed && isBrowsing(ui) && browseTab === "queue") {
@@ -9372,7 +9250,7 @@ button {
 				renderBrowseRow(row.story, list, start + index + 1, { also: row.also }),
 			);
 
-		refreshAllItemActionControls();
+		refreshFavoriteControls().catch(console.error);
 
 		renderBrowseNav(
 			list,
@@ -14285,7 +14163,13 @@ ${settingsPanelHTML()}
 	}${
 		ageLabel ? escapeHTML(ageLabel) + " " : ""
 	}<span class="item-age" data-age-id="${escapeHTML(storyID)}">${timeAgo(storyCreatedAt)}</span><span class="story-vote-status" data-vote-status-id="${escapeHTML(storyID)}"></span>
-	${showActions ? itemActionLinksHTML(storyID, story.source || "hn", watchLink) : itemActionLinksHTML("", "", watchLink)}
+	${itemActionLinksHTML(showActions ? storyID : "", story.source || "hn", watchLink, {
+		key: `${story.source || "hn"}:${storyID}`,
+		url: hnURL || story.url || "",
+		title: title || "",
+		site: story.site || (story.url ? hostLabel(story.url) : ""),
+		kind: "discussion",
+	})}
 	${
 		showTitle || !hnURL
 			? ""
@@ -15110,8 +14994,9 @@ ${settingsPanelHTML()}
       ${isLocalSource ? "" : `<a class="focus-link" href="#">focus</a>`}
 		${isLocalSource ? `<a class="edit-note-link" href="#">edit</a> | <a class="delete-note-link" href="#">delete</a>` : ""}
 		${
-			capabilities.vote
-				? itemActionLinksHTML(commentID, comment.source || "hn", "", {
+			isLocalSource
+				? ""
+				: itemActionLinksHTML(commentID, comment.source || "hn", "", {
 						key: `${comment.source || "hn"}:${commentID}`,
 						url: discussionURL(comment) || "",
 						title: comment.by ? `comment by ${comment.by}` : "comment",
@@ -15119,7 +15004,6 @@ ${settingsPanelHTML()}
 						kind: "comment",
 						parent: String(comment.storyID || ""),
 					})
-				: ""
 		}
 
       <span class="toggle">
@@ -15625,6 +15509,7 @@ ${settingsPanelHTML()}
 		}
 
 		reconcileWholeThreads(stories, ui);
+		refreshFavoriteControls().catch(console.error);
 
 		for (const story of stories) {
 			await markSeen(story.key);
@@ -20900,10 +20785,7 @@ title="Show only this discussion">
 		await loadPdfTitle(pdfViewerApp());
 		watchNoteSelection(settings);
 
-		const votesReady = Promise.all([
-			loadRememberedVotes(),
-			loadRememberedItemActions(),
-		]);
+		const votesReady = loadRememberedVotes();
 
 		const hideButton =
 			settings.hideWithoutDiscussion &&

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -9165,7 +9165,6 @@ button {
 			});
 
 			row.classList.add("browse-row-watching");
-			row.classList.toggle("browse-row-read", Boolean(entry.readAt));
 			row.classList.toggle("browse-row-fresh", fresh);
 
 			if (fresh) {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -924,6 +924,14 @@
 
 	// #region hnewhere-test-export
 
+	function favoriteKeyFor(story) {
+		if (story.source) {
+			return `${story.source}:${story.id}`;
+		}
+
+		return normalizeURL(story.url || "") || String(story.id ?? "");
+	}
+
 	function favoriteButtonHTML(about = {}) {
 		const id = String(about.id ?? about.key ?? "");
 		const key = String(about.key || "");
@@ -8504,8 +8512,8 @@ button {
 			? `${watchLink ? `\n      |\n      ${watchLink}` : ""}
       |
       <button class="item-action-link browse-unfavorite-link" type="button">unfavorite</button>`
-			: itemActionLinksHTML(story.id, story.source || "hn", watchLink, {
-					key: `${story.source || "hn"}:${story.id}`,
+			: itemActionLinksHTML(story.id, story.source, watchLink, {
+					key: favoriteKeyFor(story),
 					url: story.url,
 					title: story.title,
 					site: story.site,
@@ -14181,8 +14189,8 @@ ${settingsPanelHTML()}
 	}${
 		ageLabel ? escapeHTML(ageLabel) + " " : ""
 	}<span class="item-age" data-age-id="${escapeHTML(storyID)}">${timeAgo(storyCreatedAt)}</span><span class="story-vote-status" data-vote-status-id="${escapeHTML(storyID)}"></span>
-	${itemActionLinksHTML(showActions ? storyID : "", story.source || "hn", watchLink, {
-		key: `${story.source || "hn"}:${storyID}`,
+	${itemActionLinksHTML(showActions ? storyID : "", story.source, watchLink, {
+		key: favoriteKeyFor({ ...story, id: storyID, url: hnURL || story.url || "" }),
 		url: hnURL || story.url || "",
 		title: title || "",
 		site: story.site || (story.url ? hostLabel(story.url) : ""),

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -11676,7 +11676,7 @@ ${[
 
 #panel {
 	all:initial;
-	line-height:inherit;
+	line-height:1.4;
 	color-scheme:inherit;
 	-webkit-text-size-adjust:100%;
 	text-size-adjust:100%;

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -4599,7 +4599,16 @@ button {
 			return;
 		}
 
+		const filter = activeCommentFilter;
+
 		await renderDiscussions(renderedDiscussions, sidebarUI);
+
+		if (filter?.type === "discussion") {
+			applyDiscussionFilter(filter.key, { restore: false });
+		} else if (filter?.type === "comment") {
+			applyCommentFocus(filter.id, { restore: false });
+		}
+
 		await refreshArticleAnnotations();
 	}
 
@@ -20322,6 +20331,10 @@ title="Show only this discussion">
 		return visibleCommentIdsFromGraph(getCommentGraph(), commentIds);
 	}
 
+	function isNotepadComment(rendered) {
+		return Boolean(rendered?.element?.closest?.(".notepad-body"));
+	}
+
 	function applyFocusedDiscussion(
 		{ filter, directMatchIds, anchorElement, paintBanner, onFiltered, banner },
 		options = {},
@@ -20342,7 +20355,7 @@ title="Show only this discussion">
 			for (const rendered of renderedComments) {
 				rendered.element.classList.toggle(
 					"comment-filter-hidden",
-					!visibleCommentIds.has(rendered.id),
+					!visibleCommentIds.has(rendered.id) && !isNotepadComment(rendered),
 				);
 
 				if (

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -13410,8 +13410,13 @@ ${SUBMIT_FORM_CSS}
 	background:var(--hover-tint);
 }
 
-.notepad-add {
+.notepad-actions {
+	display:inline-flex;
+	align-items:baseline;
 	margin-left:auto;
+}
+
+.notepad-add {
 	padding:0;
 	border:0;
 	background:none;
@@ -16062,7 +16067,11 @@ ${settingsPanelHTML()}
 		add.textContent = "add a note";
 		add.onclick = () => onAdd?.(add);
 
-		head.append(add, toggle);
+		const actions = document.createElement("span");
+
+		actions.className = "notepad-actions";
+		actions.append(add, toggle);
+		head.append(actions);
 		body.className = "notepad-body";
 		foot.className = "notepad-rule notepad-rule-close";
 		section.append(head, body, foot);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -13457,6 +13457,13 @@ ${SUBMIT_FORM_CSS}
 	max-width:100%;
 }
 
+.text hr,
+.story-text hr {
+	border:none;
+	border-top:1px solid var(--surface-divider);
+	margin:14px 0;
+}
+
 .text pre,
 .text ul,
 .text ol,

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -10745,13 +10745,15 @@ header {
 }
 
 .item-action-link:enabled:focus-visible,
-.page-header-watch:focus-visible {
+.page-header-watch:focus-visible,
+.page-header-disclosure:focus-visible {
 	text-decoration:underline;
 }
 
 @media (hover: hover) {
 	.item-action-link:enabled:hover,
-	.page-header-watch:hover {
+	.page-header-watch:hover,
+	.page-header-disclosure:hover {
 		text-decoration:underline;
 	}
 }

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -11050,10 +11050,10 @@ header button svg {
 	-webkit-appearance:none;
 	box-sizing:border-box;
 	flex:0 0 auto;
-	width:13px;
-	height:13px;
+	width:15px;
+	height:15px;
 	font-size:inherit;
-	margin:calc((1.35em - 13px) / 2) 0 0;
+	margin:calc((1.35em - 15px) / 2) 0 0;
 	display:inline-grid;
 	place-content:center;
 	border:1px solid var(--help-border);
@@ -11071,8 +11071,8 @@ header button svg {
 
 .settings-option input[type="checkbox"]:checked::after {
 	content:"";
-	width:6px;
-	height:3px;
+	width:7px;
+	height:3.5px;
 	border-left:1.5px solid #fff;
 	border-bottom:1.5px solid #fff;
 	transform:translateY(-1px) rotate(-45deg);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -637,6 +637,8 @@
 				title: item.title || "",
 				site: item.site || "",
 				kind: item.kind || "discussion",
+				context: item.context || "",
+				by: item.by || "",
 				source: item.source || "",
 				id: item.id || "",
 				parent: item.parent || "",
@@ -924,6 +926,35 @@
 
 	// #region hnewhere-test-export
 
+	const FAVORITE_EXCERPT_CHARS = 140;
+
+	function favoriteExcerpt(value, limit) {
+		const text = String(value ?? "")
+			.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, " ")
+			.replace(/<[^>]*>/g, " ")
+			.replace(/&(?:nbsp|amp|lt|gt|quot|#39);/g, (entity) =>
+				({
+					"&nbsp;": " ",
+					"&amp;": "&",
+					"&lt;": "<",
+					"&gt;": ">",
+					"&quot;": '"',
+					"&#39;": "'",
+				})[entity],
+			)
+			.replace(/\s+/g, " ")
+			.trim();
+
+		if (text.length <= limit) {
+			return text;
+		}
+
+		const cut = text.slice(0, limit);
+		const boundary = cut.lastIndexOf(" ");
+
+		return (boundary > limit / 2 ? cut.slice(0, boundary) : cut).trim() + "…";
+	}
+
 	function favoriteKeyFor(story) {
 		if (story.source) {
 			return `${story.source}:${story.id}`;
@@ -948,6 +979,8 @@
       data-favorite-title="${escapeHTML(about.title || "")}"
       data-favorite-site="${escapeHTML(about.site || "")}"
       data-favorite-kind="${escapeHTML(about.kind || "discussion")}"
+      data-favorite-context="${escapeHTML(about.context || "")}"
+      data-favorite-by="${escapeHTML(about.by || "")}"
       data-favorite-parent="${escapeHTML(about.parent || "")}">favorite</button>`;
 	}
 
@@ -1027,6 +1060,8 @@
 				title: button.dataset.favoriteTitle || "",
 				site: button.dataset.favoriteSite || "",
 				kind: button.dataset.favoriteKind || "discussion",
+				context: button.dataset.favoriteContext || "",
+				by: button.dataset.favoriteBy || "",
 				source: sourceID,
 				id: itemId,
 				parent: button.dataset.favoriteParent || "",
@@ -4618,12 +4653,21 @@ button {
 		const kept = notes.slice(-NOTES_PER_DOCUMENT);
 
 		await save(noteStorageKey(ref), { version: 1, notes: kept });
-		await rememberNotedDocument(ref, kept.length);
+		await rememberNotedDocument(ref, kept);
 
 		return kept;
 	}
 
-	async function rememberNotedDocument(ref, count) {
+	function latestNoteExcerpt(notes) {
+		const latest = [...notes].sort(
+			(a, b) => (b.edited || b.created || 0) - (a.edited || a.created || 0),
+		)[0];
+
+		return favoriteExcerpt(latest?.text || latest?.exact || "", FAVORITE_EXCERPT_CHARS);
+	}
+
+	async function rememberNotedDocument(ref, notes) {
+		const count = notes.length;
 		const stored = await load(NOTES_INDEX_KEY, []);
 		const entries = (Array.isArray(stored) ? stored : []).filter(
 			(entry) => entry?.key !== noteStorageKey(ref),
@@ -4636,6 +4680,7 @@ button {
 				id: ref.id,
 				url: location.href,
 				title: pageTitle(),
+				excerpt: latestNoteExcerpt(notes),
 				count,
 				updated: Date.now(),
 			});
@@ -8489,6 +8534,7 @@ button {
 	}
 
 	function renderBrowseRow(story, container, rank, options = {}) {
+		const isWriting = story.kind === "comment" || story.kind === "noted";
 		const discussions = [story, ...(options.also || [])];
 		const totalComments = discussions.reduce(
 			(sum, each) => sum + (each.descendants || 0),
@@ -8520,7 +8566,11 @@ button {
 					kind: "discussion",
 				});
 
-		const meta = options.noted
+		const meta = story.kind === "comment"
+			? `${story.by ? `by ${escapeHTML(story.by)}` : ""}
+	<span class="item-age">${escapeHTML(timeAgo(story.time))}</span>
+	${actions}`
+			: options.noted
 			? `${escapeHTML(pluralize(story.noteCount || 0, "note"))}
 	<span class="item-age">${escapeHTML(timeAgo(story.time))}</span>
 	${queueLink}
@@ -8545,13 +8595,26 @@ button {
 		row.dataset.storyId = String(story.id);
 		row.innerHTML = `
 	<div class="browse-rank">${
-		options.bullet ? (options.fresh ? "&#9679;" : "&#9675;") : `${rank}.`
+		options.bullet
+			? options.fresh
+				? "&#9679;"
+				: "&#9675;"
+			: rank
+				? `${rank}.`
+				: "&#8226;"
 	}</div>
 	<div class="browse-main">
 	<div class="story-title">
 	<a class="browse-title-link" href="${escapeHTML(story.url)}">${escapeHTML(story.title)}</a>
-	${story.site ? `<span class="browse-site">(${escapeHTML(story.site)})</span>` : ""}
+	${story.site && !isWriting ? `<span class="browse-site">(${escapeHTML(story.site)})</span>` : ""}
 	</div>
+	${
+		story.context
+			? `<div class="browse-context">${escapeHTML(story.context)}${
+					story.site ? ` <span class="browse-site">(${escapeHTML(story.site)})</span>` : ""
+				}</div>`
+			: ""
+	}
 	<div class="story-meta">
 	${meta}
 	</div>
@@ -8712,26 +8775,30 @@ button {
 	}
 
 	function collectionRow(entry, list, rank, options = {}) {
+		const kind = entry.kind === "comment" ? "comment" : options.noted ? "noted" : "discussion";
+		const page = entry.title || entry.url || entry.id;
+
 		return renderBrowseRow(
 			{
 				id: entry.key,
 				key: entry.key,
 				source: "",
+				kind,
 				permalink: "",
 				url: entry.url || "",
-				title: entry.title || entry.url || entry.id,
-				by: "",
+				title: kind === "noted" ? entry.excerpt || page : page,
+				context: kind === "noted" ? page : entry.context || "",
+				by: entry.by || "",
 				score: 0,
 				time: Math.floor((entry.updated || entry.addedAt || Date.now()) / 1000),
 				descendants: entry.count || 0,
-				site: entry.url ? hostLabel(entry.url) : "",
+				site: entry.site || (entry.url ? hostLabel(entry.url) : ""),
 				noteCount: entry.count || 0,
 			},
 			list,
 			rank,
 			{
-				noted: Boolean(entry.count),
-				watchable: (entry.kind || "discussion") !== "comment",
+				watchable: kind !== "comment",
 				...options,
 			},
 		);
@@ -8774,7 +8841,7 @@ button {
 			subhead(list, "comments");
 
 			for (const entry of comments) {
-				collectionRow(entry, list, (rank += 1), {
+				collectionRow(entry, list, null, {
 					unfavorite: entry.key,
 					reload,
 				});
@@ -8785,7 +8852,7 @@ button {
 			subhead(list, "noted");
 
 			for (const entry of noted) {
-				collectionRow(entry, list, (rank += 1), { reload });
+				collectionRow(entry, list, null, { noted: true, reload });
 			}
 		}
 
@@ -10436,6 +10503,15 @@ header {
 .browse-site {
 	color:var(--meta);
 	font-size:11px;
+}
+
+.browse-context {
+	margin-top:1px;
+	color:var(--meta);
+	font-size:11px;
+	overflow:hidden;
+	text-overflow:ellipsis;
+	white-space:nowrap;
 }
 
 .browse-title-link:visited {
@@ -15024,8 +15100,10 @@ ${settingsPanelHTML()}
 				: itemActionLinksHTML(commentID, comment.source || "hn", "", {
 						key: `${comment.source || "hn"}:${commentID}`,
 						url: discussionURL(comment) || "",
-						title: comment.by ? `comment by ${comment.by}` : "comment",
-						site: "",
+						title: favoriteExcerpt(comment.bodyHTML, FAVORITE_EXCERPT_CHARS),
+						site: getSource(comment.source)?.shortLabel || "",
+						context: discussion.title || discussion.label || "",
+						by: comment.authorName || comment.author || "",
 						kind: "comment",
 						parent: String(comment.storyID || ""),
 					})

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Backchannel
 // @namespace    https://github.com/twalichiewicz/HNewhere
-// @version      1.6.8
+// @version      1.6.9
 // @license      MIT
 // @updateURL    https://raw.githubusercontent.com/twalichiewicz/Backchannel/main/HNewhere.user.js
 // @downloadURL  https://raw.githubusercontent.com/twalichiewicz/Backchannel/main/HNewhere.user.js

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -10665,7 +10665,7 @@ header {
 }
 
 .browse-row-loose {
-	padding-bottom:0;
+	padding:0 0 0 8px;
 }
 
 .browse-row-loose + .browse-row-loose {
@@ -10673,7 +10673,7 @@ header {
 }
 
 .browse-row-loose .browse-rank {
-	min-width:0;
+	display:none;
 }
 
 .browse-main {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -4425,6 +4425,7 @@ button {
 
 		if (body.querySelector(".note-editor")) {
 			body.style.maxHeight = "";
+			body.style.overflow = "visible";
 			return;
 		}
 
@@ -4471,7 +4472,7 @@ button {
 
 		text.hidden = true;
 		text.after(held.editor);
-		held.field.focus();
+		held.field.focus({ preventScroll: true });
 		settleNotepad(div);
 	}
 
@@ -4504,8 +4505,26 @@ button {
 			held.editor.classList.add("is-open");
 			held.editor.style.maxHeight = `${held.editor.scrollHeight}px`;
 			settleNotepad(held.editor);
-			held.field.focus();
+			held.field.focus({ preventScroll: true });
+
+			window.setTimeout(() => releaseNotepadDraft(held.editor), 240);
 		});
+	}
+
+	function releaseNotepadDraft(draft) {
+		if (!draft?.isConnected || !draft.classList.contains("is-open")) {
+			return;
+		}
+
+		draft.style.maxHeight = "none";
+		draft.style.overflow = "visible";
+		draft.scrollTop = 0;
+	}
+
+	function clampNotepadDraft(draft) {
+		draft.style.overflow = "";
+		draft.style.maxHeight = `${draft.scrollHeight}px`;
+		draft.getBoundingClientRect();
 	}
 
 	function closeNotepadDraft(section, body) {
@@ -4519,6 +4538,7 @@ button {
 			return;
 		}
 
+		clampNotepadDraft(draft);
 		draft.style.maxHeight = "0px";
 		draft.classList.remove("is-open");
 
@@ -8934,7 +8954,7 @@ button {
 
 		title.hidden = true;
 		title.after(held.editor);
-		held.field.focus();
+		held.field.focus({ preventScroll: true });
 	}
 
 	async function collectedNotesFor(page) {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -563,10 +563,15 @@
 			: entry + " (domain-wide)";
 	}
 
+	function queueKey(story) {
+		return story.key || normalizeURL(story.url || "");
+	}
+
 	function addToQueue(entries, story, now) {
 		const list = Array.isArray(entries) ? entries : [];
+		const key = queueKey(story);
 
-		if (list.some((entry) => entry.key === story.key)) {
+		if (list.some((entry) => queueKey(entry) === key)) {
 			return list;
 		}
 
@@ -574,7 +579,7 @@
 			...list,
 			{
 				id: story.id,
-				key: story.key,
+				key,
 				source: story.source,
 				permalink: story.permalink || "",
 				url: story.url,
@@ -17117,10 +17122,6 @@ title="Show only this discussion">
 	// -------------------------
 	// URL helpers
 	// -------------------------
-
-	function queueKey(story) {
-		return story.key || normalizeURL(story.url || "");
-	}
 
 	function sameURL(a, b) {
 		return normalizeURL(a) === normalizeURL(b);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -356,7 +356,6 @@
 		hideWithoutDiscussion: false,
 		showButtonWithQueue: false,
 		notifyOnWatch: false,
-		syncSources: {},
 		sources: undefined,
 		theme: "auto",
 		buttonShape: "circle",
@@ -1073,12 +1072,6 @@
 		seen.forEach(refreshItemActionControls);
 	}
 
-	function sourceSyncEnabled(settings, sourceID) {
-		const map = settings?.syncSources;
-
-		return Boolean(map && typeof map === "object" && map[sourceID]);
-	}
-
 	async function toggleFavorite(item, settings) {
 		const entries = await loadFavoriteEntries();
 		const on = entries.some((entry) => entry.key === item.key);
@@ -1120,9 +1113,7 @@
 				});
 			}
 
-			const settings = await loadSettings();
-
-			if (kind !== "fave" || sourceSyncEnabled(settings, sourceID)) {
+			if (kind !== "fave") {
 				await openItemActionPopup(sourceID, itemId, itemId, action, null);
 			}
 		} finally {
@@ -2995,15 +2986,6 @@
 ${
 	source.caveat
 		? `<div class="settings-option-hint">${escapeHTML(source.caveat)}${source.slow ? `<p class="settings-option-hint-slow">This source takes longer to fetch comments, so they may take a moment to appear.</p>` : ""}</div>`
-		: ""
-}${
-	sourceHasItemActions(source.id)
-		? `<div class="settings-suboptions" data-suboptions-of="source-${escapeHTML(source.id)}">
-<label class="settings-option sub-option">
-<input${idPrefix ? ` id="${escapeHTML(idPrefix + "sync-" + source.id)}"` : ""} data-source-sync="${escapeHTML(source.id)}" type="checkbox">
-<span>Also favourite and flag on ${escapeHTML(source.label)}</span>
-</label>
-</div>`
 		: ""
 }`,
 			)
@@ -5063,16 +5045,14 @@ button {
 	const WATCH_BATCH = 4;
 	const WATCH_POLL_DELAY_MS = 5000;
 
+	function notificationsAllowed() {
+		return (
+			typeof Notification !== "undefined" && Notification.permission === "granted"
+		);
+	}
+
 	async function grantNotifications() {
 		if (typeof Notification === "undefined") {
-			return false;
-		}
-
-		if (Notification.permission === "granted") {
-			return true;
-		}
-
-		if (Notification.permission === "denied") {
 			return false;
 		}
 
@@ -5219,7 +5199,7 @@ button {
 						await saveQueue(addToQueue(queued, story, now));
 					}
 
-					if (settings.notifyOnWatch) {
+					if (settings.notifyOnWatch && notificationsAllowed()) {
 						notifyWatch(entry, found.length);
 					}
 				}
@@ -11994,9 +11974,6 @@ ${
 <span>Except when something is waiting in your queue</span>
 </label>
 </div>
-<div class="settings-option-hint">
-When off, pages with no discussion get a greyed-out button that offers to submit them.
-</div>
 </div>
 
 <div class="settings-group">
@@ -12040,7 +12017,7 @@ All stored locally.
 <span>Notify me when a watched discussion has something new</span>
 </label>
 <div class="settings-option-hint">
-Sends a desktop notification the moment a watched page has a discussion worth reading.
+Sends a system notification when a watched page has new comments
 </div>
 </div>
 
@@ -12317,18 +12294,20 @@ ${[
 				if (input) {
 					input.checked = Boolean(settings[key]);
 
+					if (
+						key === "notifyOnWatch" &&
+						input.checked &&
+						typeof Notification !== "undefined" &&
+						Notification.permission === "denied"
+					) {
+						input.checked = false;
+						saveSettings({ notifyOnWatch: false }).catch(console.error);
+					}
+
 					if (HINTED_SETTINGS.has(key)) {
 						syncOptionHint(input);
 					}
 				}
-			}
-
-			for (const input of settingsPanel.querySelectorAll(
-				"input[data-source-sync]",
-			)) {
-				input.checked = Boolean(
-					(settings.syncSources || {})[input.dataset.sourceSync],
-				);
 			}
 
 			for (const [key, inputs] of Object.entries(settingsRadios)) {
@@ -12349,17 +12328,6 @@ ${[
 			)) {
 				input.checked = Boolean(sourceState[input.dataset.source]);
 				syncSourceHint(input);
-			}
-
-			for (const group of settingsPanel.querySelectorAll(
-				'[data-suboptions-of^="source-"]',
-			)) {
-				const id = group.dataset.suboptionsOf.slice("source-".length);
-				const on = settingsPanel.querySelector(
-					`input[data-source="${CSS.escape(id)}"]`,
-				)?.checked;
-
-				group.classList.toggle("is-visible", Boolean(on));
 			}
 
 			for (const group of suboptionGroups) {
@@ -12543,31 +12511,10 @@ ${[
 		});
 
 		settingsPanel.addEventListener("change", async (event) => {
-			const syncInput = event.target.closest("input[data-source-sync]");
-
-			if (syncInput) {
-				const current = await loadSettings();
-
-				await saveSettings({
-					syncSources: {
-						...(current.syncSources || {}),
-						[syncInput.dataset.sourceSync]: syncInput.checked,
-					},
-				});
-
-				return;
-			}
-
 			const sourceInput = event.target.closest("input[data-source]");
 
 			if (sourceInput) {
 				syncSourceHint(sourceInput);
-
-				settingsPanel
-					.querySelector(
-						`[data-suboptions-of="source-${CSS.escape(sourceInput.dataset.source)}"]`,
-					)
-					?.classList.toggle("is-visible", sourceInput.checked);
 
 				const current = await loadSettings();
 
@@ -12590,6 +12537,19 @@ ${[
 				return;
 			}
 
+			if (input.dataset.setting === "notifyOnWatch") {
+				const allowed = input.checked ? await grantNotifications() : false;
+
+				input.checked = input.checked && allowed;
+
+				applySettingsPanelState(
+					await saveSettings({ notifyOnWatch: input.checked }),
+				);
+				settlePanesHeight();
+
+				return;
+			}
+
 			const settings = await saveSettings({
 				[input.dataset.setting]:
 					input.type === "radio" ? input.value : input.checked,
@@ -12599,15 +12559,6 @@ ${[
 			settlePanesHeight();
 
 			const setting = input.dataset.setting;
-
-			if (setting === "notifyOnWatch") {
-				if (input.checked && !(await grantNotifications())) {
-					applySettingsPanelState(await saveSettings({ notifyOnWatch: false }));
-					settlePanesHeight();
-				}
-
-				return;
-			}
 
 			if (setting === "theme") {
 				refreshThemeSurfaces();
@@ -15998,7 +15949,11 @@ ${settingsPanelHTML()}
 	stories.length > 1
 		? `<span class="page-header-total">${escapeHTML(pluralize(total, "comment"))}</span> across <button type="button" class="page-header-disclosure" aria-expanded="false" aria-controls="source-strip">${escapeHTML(pluralize(stories.length, "discussion"))}</button><span class="page-header-sep">|</span>`
 		: ""
-}<button type="button" class="page-header-watch" aria-pressed="false">watch discussion</button></div>
+}${
+	stories.length > 1
+		? `<button type="button" class="page-header-watch" aria-pressed="false">watch</button>`
+		: ""
+}</div>
 <div class="source-strip${stories.length > 1 ? "" : " source-strip-single"}" id="source-strip">
 ${
 	stories

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -11115,8 +11115,8 @@ header button svg {
 
 .settings-credits a {
 	color:var(--muted);
-	text-decoration:underline;
-	text-decoration-color:var(--underline-soft);
+	text-decoration:underline dotted;
+	text-decoration-color:var(--border);
 	text-underline-offset:2px;
 }
 
@@ -11966,9 +11966,11 @@ header button svg {
 	border:0;
 	background:none;
 	color:var(--muted);
+	font:inherit;
 	font-size:11px;
-	text-decoration:underline;
+	text-decoration:underline dotted;
 	text-underline-offset:2px;
+	text-decoration-color:var(--border);
 	cursor:pointer;
 }
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -8595,6 +8595,7 @@ button {
 	function renderBrowseRow(story, container, rank, options = {}) {
 		const isWriting = story.kind === "comment" || story.kind === "noted";
 		const discussions = [story, ...(options.also || [])];
+		const counted = discussions.some((each) => Number.isFinite(each.descendants));
 		const totalComments = discussions.reduce(
 			(sum, each) => sum + (each.descendants || 0),
 			0,
@@ -8652,8 +8653,7 @@ button {
 	<span class="item-age">${escapeHTML(timeAgo(story.time))}</span>
 	${queueLink}
 	${actions}
-	|
-	${commentTotal}`;
+	${counted ? `|\n\t${commentTotal}` : ""}`;
 
 		const row = document.createElement("div");
 		row.className =
@@ -8900,7 +8900,7 @@ button {
 				score: 0,
 				time:
 					entry.time || Math.floor((entry.updated || entry.addedAt || Date.now()) / 1000),
-				descendants: entry.count || 0,
+				descendants: entry.count,
 				site: entry.site || (entry.url ? hostLabel(entry.url) : ""),
 			},
 			list,
@@ -9056,7 +9056,7 @@ button {
 		}
 
 		if (noted.length) {
-			subhead(list, "noted");
+			subhead(list, "notes");
 
 			for (const entry of noted) {
 				noteCollectionRow(entry, list, {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -4597,19 +4597,59 @@ button {
 		await reopenForNotes();
 	}
 
+	async function refreshNotepadInPlace() {
+		const section = sidebarUI?.body?.querySelector("[data-notes-section]");
+		const body = section?.querySelector(".notepad-body");
+
+		if (!body) {
+			return false;
+		}
+
+		const notes = await loadNotes();
+		const discussion = notesCollective(notes, pageAddress());
+		const toggle = section.querySelector(".notepad-toggle");
+		const empty = !notes.length;
+
+		renderedComments = renderedComments.filter(
+			(rendered) => !body.contains(rendered.element),
+		);
+		body.replaceChildren();
+
+		toggle.hidden = empty;
+		toggle.textContent = empty ? "show" : "hide";
+		toggle.setAttribute("aria-expanded", empty ? "false" : "true");
+		section.classList.toggle("is-collapsed", empty);
+		body.style.maxHeight = empty ? "0px" : "";
+
+		if (discussion) {
+			const thread = notesThread(discussion);
+			const collapsedKeys = await loadCollapsed();
+
+			for (const key of thread.rootKeys) {
+				await renderComment(
+					key,
+					thread,
+					body,
+					discussion,
+					0,
+					collapsedKeys,
+					sidebarGeneration,
+				);
+			}
+		}
+
+		settleNotepad(body);
+
+		return true;
+	}
+
 	async function reopenForNotes() {
 		if (!sidebarUI) {
 			return;
 		}
 
-		const filter = activeCommentFilter;
-
-		await renderDiscussions(renderedDiscussions, sidebarUI);
-
-		if (filter?.type === "discussion") {
-			applyDiscussionFilter(filter.key, { restore: false });
-		} else if (filter?.type === "comment") {
-			applyCommentFocus(filter.id, { restore: false });
+		if (!(await refreshNotepadInPlace())) {
+			await renderDiscussions(renderedDiscussions, sidebarUI);
 		}
 
 		await refreshArticleAnnotations();

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -14448,7 +14448,6 @@ ${settingsPanelHTML()}
 			? `<button class="item-action-link browse-watch-link" type="button">watch</button>`
 			: "";
 
-		const showActions = options.actions !== false;
 		const showTitle = options.showTitle !== false;
 		const showComposer = options.compose === true;
 		const storyAuthor = story.author ?? story.by;
@@ -14504,7 +14503,7 @@ ${settingsPanelHTML()}
 	}${
 		ageLabel ? escapeHTML(ageLabel) + " " : ""
 	}<span class="item-age" data-age-id="${escapeHTML(storyID)}">${timeAgo(storyCreatedAt)}</span><span class="story-vote-status" data-vote-status-id="${escapeHTML(storyID)}"></span>
-	${itemActionLinksHTML(showActions ? storyID : "", story.source, watchLink, {
+	${itemActionLinksHTML(storyID, story.source, watchLink, {
 		key: favoriteKeyFor({ ...story, id: storyID, url: hnURL || story.url || "" }),
 		url: hnURL || story.url || "",
 		title: title || "",
@@ -15699,7 +15698,6 @@ ${settingsPanelHTML()}
 			const canReply = Boolean(getSource(story.source)?.capabilities.reply);
 			const resolved = storyTitle(story, page, disambiguating);
 			const block = renderStory(story, details, {
-				actions: canVote,
 				compose: canReply,
 				title: resolved,
 				showTitle: true,
@@ -15734,14 +15732,10 @@ ${settingsPanelHTML()}
 				onAdd: () => startNotepadDraft(held.section, held.body),
 			});
 
-			const composer =
-				stories.length === 1 ? ui.body.querySelector(".comment-composer") : null;
-
-			if (composer?.parentNode) {
-				composer.parentNode.insertBefore(held.section, composer);
-			} else {
-				ui.body.insertBefore(held.section, ui.body.querySelector(".page-sort"));
-			}
+			ui.body.insertBefore(
+				held.section,
+				ui.body.querySelector(".page-sort") || comments,
+			);
 
 			if (notesDiscussion) {
 				const thread = notesThread(notesDiscussion);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -197,6 +197,7 @@
 		blocked: "HNewhere:blocked_sites",
 		queue: "HNewhere:queue",
 		favorites: "HNewhere:favorites",
+		pendingFocus: "HNewhere:pending_focus",
 		watches: "HNewhere:watches",
 	};
 
@@ -644,6 +645,8 @@
 				kind: item.kind || "discussion",
 				context: item.context || "",
 				by: item.by || "",
+				time: Number(item.time) || 0,
+				focus: item.focus || "",
 				source: item.source || "",
 				id: item.id || "",
 				parent: item.parent || "",
@@ -986,6 +989,8 @@
       data-favorite-kind="${escapeHTML(about.kind || "discussion")}"
       data-favorite-context="${escapeHTML(about.context || "")}"
       data-favorite-by="${escapeHTML(about.by || "")}"
+      data-favorite-time="${escapeHTML(String(about.time || ""))}"
+      data-favorite-focus="${escapeHTML(about.focus || "")}"
       data-favorite-parent="${escapeHTML(about.parent || "")}">favorite</button>`;
 	}
 
@@ -1067,6 +1072,8 @@
 				kind: button.dataset.favoriteKind || "discussion",
 				context: button.dataset.favoriteContext || "",
 				by: button.dataset.favoriteBy || "",
+				time: Number(button.dataset.favoriteTime) || 0,
+				focus: button.dataset.favoriteFocus || "",
 				source: sourceID,
 				id: itemId,
 				parent: button.dataset.favoriteParent || "",
@@ -8571,15 +8578,19 @@ button {
 					kind: "discussion",
 				});
 
+		const inPost = story.context
+			? `in ${escapeHTML(story.context)}${story.site ? ` (${escapeHTML(story.site)})` : ""}`
+			: "";
+
 		const meta = story.kind === "comment"
-			? `${story.by ? `by ${escapeHTML(story.by)}` : ""}
+			? `${story.by ? `by ${escapeHTML(story.by)} ` : ""}${inPost}
 	<span class="item-age">${escapeHTML(timeAgo(story.time))}</span>
 	${actions}`
-			: options.noted
-			? `${escapeHTML(pluralize(story.noteCount || 0, "note"))}
+			: story.kind === "noted"
+			? `${inPost}
 	<span class="item-age">${escapeHTML(timeAgo(story.time))}</span>
-	${queueLink}
-	${actions}`
+	|
+	<button class="item-action-link browse-delete-note-link" type="button">delete</button>`
 			: story.watchPlaceholder
 			? `<span class="item-age">watching since ${escapeHTML(timeAgo(story.time))}</span>
 	${queueLink}
@@ -8610,16 +8621,9 @@ button {
 	}</div>
 	<div class="browse-main">
 	<div class="story-title">
-	<a class="browse-title-link" href="${escapeHTML(story.url)}">${escapeHTML(story.title)}</a>
+	<a class="browse-title-link${isWriting ? " browse-quote" : ""}" href="${escapeHTML(story.url)}">${escapeHTML(story.title)}</a>
 	${story.site && !isWriting ? `<span class="browse-site">(${escapeHTML(story.site)})</span>` : ""}
 	</div>
-	${
-		story.context
-			? `<div class="browse-context">${escapeHTML(story.context)}${
-					story.site ? ` <span class="browse-site">(${escapeHTML(story.site)})</span>` : ""
-				}</div>`
-			: ""
-	}
 	<div class="story-meta">
 	${meta}
 	</div>
@@ -8743,6 +8747,61 @@ button {
 		}
 	}
 
+	const PENDING_FOCUS_TTL = 60000;
+
+	async function rememberPendingFocus(url, commentKey) {
+		const page = normalizeURL(url || "");
+
+		if (!page || !commentKey) {
+			return;
+		}
+
+		await save(STORAGE.pendingFocus, { page, commentKey, at: Date.now() });
+	}
+
+	async function applyPendingFocus() {
+		const commentKey = await takePendingFocus();
+
+		if (commentKey && getCommentGraph().byId.has(commentKey)) {
+			applyCommentFocus(commentKey);
+		}
+	}
+
+	async function takePendingFocus() {
+		const pending = await load(STORAGE.pendingFocus, null);
+
+		if (!pending?.commentKey) {
+			return null;
+		}
+
+		await save(STORAGE.pendingFocus, null);
+
+		const stale = Date.now() - (pending.at || 0) > PENDING_FOCUS_TTL;
+
+		return !stale && pending.page === normalizeURL(pageAddress())
+			? pending.commentKey
+			: null;
+	}
+
+	async function loadCollectedNotes() {
+		const documents = await loadNotedIndex();
+		const lists = await Promise.all(
+			documents.map(async (document) => {
+				const notes = keptNotes(await load(document.key, null));
+
+				return notes.map((note) => ({ note, document }));
+			}),
+		);
+
+		return lists
+			.flat()
+			.sort(
+				(a, b) =>
+					(b.note.edited || b.note.created || 0) -
+					(a.note.edited || a.note.created || 0),
+			);
+	}
+
 	async function loadNotedIndex() {
 		return notedDocuments(await load(NOTES_INDEX_KEY, [])).sort(
 			(a, b) => (b.updated || 0) - (a.updated || 0),
@@ -8791,28 +8850,67 @@ button {
 				kind,
 				permalink: "",
 				url: entry.url || "",
-				title: kind === "noted" ? entry.excerpt || page : page,
-				context: kind === "noted" ? page : entry.context || "",
+				title: page,
+				context: entry.context || "",
 				by: entry.by || "",
 				score: 0,
-				time: Math.floor((entry.updated || entry.addedAt || Date.now()) / 1000),
+				time:
+					entry.time || Math.floor((entry.updated || entry.addedAt || Date.now()) / 1000),
 				descendants: entry.count || 0,
 				site: entry.site || (entry.url ? hostLabel(entry.url) : ""),
-				noteCount: entry.count || 0,
 			},
 			list,
 			rank,
 			{
-				watchable: kind !== "comment",
+				watchable: kind !== "comment" && kind !== "noted",
 				...options,
 			},
 		);
 	}
 
+	function noteCollectionRow({ note, document }, list, onDelete) {
+		const row = collectionRow(
+			{
+				key: note.id,
+				kind: "noted",
+				url: document.url || "",
+				title: favoriteExcerpt(note.text, FAVORITE_EXCERPT_CHARS),
+				context: document.title || document.url || document.id,
+				time: note.edited || note.created || 0,
+				site: document.url ? hostLabel(document.url) : "",
+			},
+			list,
+			null,
+			{ noted: true },
+		);
+
+		const drop = row.querySelector(".browse-delete-note-link");
+
+		if (drop) {
+			drop.onclick = () => onDelete(document, note).catch(console.error);
+		}
+
+		return row;
+	}
+
+	async function deleteCollectedNote(document, note) {
+		const ref = { kind: document.kind, id: document.id };
+		const notes = keptNotes(await load(noteStorageKey(ref), null));
+
+		await saveNotes(
+			notes.filter((kept) => kept.id !== note.id),
+			ref,
+		);
+
+		if (sameURL(document.url || "", location.href)) {
+			await reopenForNotes();
+		}
+	}
+
 	async function renderCollectionView(ui, list) {
 		const [favorites, noted] = await Promise.all([
 			loadFavoriteEntries(),
-			loadNotedIndex(),
+			loadCollectedNotes(),
 		]);
 		const saved = favoritesOfKind(favorites, "discussion");
 		const comments = favoritesOfKind(favorites, "comment");
@@ -8846,10 +8944,23 @@ button {
 			subhead(list, "favorite comments");
 
 			for (const entry of comments) {
-				collectionRow(entry, list, null, {
+				const row = collectionRow(entry, list, null, {
 					unfavorite: entry.key,
 					reload,
 				});
+
+				const open = row.querySelector(".browse-title-link");
+
+				if (open && entry.focus && entry.url) {
+					open.onclick = (event) => {
+						event.preventDefault();
+						rememberPendingFocus(entry.url, entry.focus)
+							.catch(console.error)
+							.then(() => {
+								location.href = entry.url;
+							});
+					};
+				}
 			}
 		}
 
@@ -8857,7 +8968,10 @@ button {
 			subhead(list, "noted");
 
 			for (const entry of noted) {
-				collectionRow(entry, list, null, { noted: true, reload });
+				noteCollectionRow(entry, list, async (document, note) => {
+					await deleteCollectedNote(document, note);
+					await reload();
+				});
 			}
 		}
 
@@ -10510,13 +10624,27 @@ header {
 	font-size:11px;
 }
 
-.browse-context {
-	margin-top:1px;
-	color:var(--meta);
-	font-size:11px;
-	overflow:hidden;
-	text-overflow:ellipsis;
-	white-space:nowrap;
+.browse-quote {
+	position:relative;
+	display:inline-block;
+	padding-left:15px;
+	color:var(--quote-text);
+	font-style:italic;
+}
+
+.browse-quote::before {
+	content:"❛";
+	position:absolute;
+	left:0;
+	top:0;
+	color:var(--quote-ornament);
+	font-size:15px;
+	font-style:normal;
+	line-height:1.35;
+}
+
+.browse-quote:visited {
+	color:var(--quote-text);
 }
 
 .browse-title-link:visited {
@@ -15104,11 +15232,13 @@ ${settingsPanelHTML()}
 				? ""
 				: itemActionLinksHTML(commentID, comment.source || "hn", "", {
 						key: `${comment.source || "hn"}:${commentID}`,
-						url: discussionURL(comment) || "",
+						url: discussion.articleURL || discussionURL(comment) || "",
+						focus: comment.key,
 						title: favoriteExcerpt(comment.bodyHTML, FAVORITE_EXCERPT_CHARS),
 						site: getSource(comment.source)?.shortLabel || "",
 						context: discussion.title || discussion.label || "",
 						by: comment.authorName || comment.author || "",
+						time: comment.createdAt || 0,
 						kind: "comment",
 						parent: String(comment.storyID || ""),
 					})
@@ -15618,6 +15748,7 @@ ${settingsPanelHTML()}
 
 		reconcileWholeThreads(stories, ui);
 		refreshFavoriteControls().catch(console.error);
+		applyPendingFocus().catch(console.error);
 
 		for (const story of stories) {
 			await markSeen(story.key);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -924,6 +924,25 @@
 
 	// #region hnewhere-test-export
 
+	function favoriteButtonHTML(about = {}) {
+		const id = String(about.id ?? about.key ?? "");
+		const key = String(about.key || "");
+
+		if (!key) {
+			return "";
+		}
+
+		return `<button class="item-action-link" type="button"
+      data-item-action="fave" data-item-action-source="${escapeHTML(String(about.source || ""))}"
+      data-item-action-id="${escapeHTML(id)}"
+      data-favorite-key="${escapeHTML(key)}"
+      data-favorite-url="${escapeHTML(about.url || "")}"
+      data-favorite-title="${escapeHTML(about.title || "")}"
+      data-favorite-site="${escapeHTML(about.site || "")}"
+      data-favorite-kind="${escapeHTML(about.kind || "discussion")}"
+      data-favorite-parent="${escapeHTML(about.parent || "")}">favorite</button>`;
+	}
+
 	function itemActionLinksHTML(itemId, sourceID, watchLink, about = {}) {
 		const between = watchLink ? `\n      |\n      ${watchLink}` : "";
 
@@ -931,20 +950,16 @@
 			return between;
 		}
 
-		const id = escapeHTML(String(itemId));
-		const source = escapeHTML(String(sourceID || ""));
-		const meta =
-			` data-favorite-key="${escapeHTML(about.key || source + ":" + id)}"` +
-			` data-favorite-url="${escapeHTML(about.url || "")}"` +
-			` data-favorite-title="${escapeHTML(about.title || "")}"` +
-			` data-favorite-site="${escapeHTML(about.site || "")}"` +
-			` data-favorite-kind="${escapeHTML(about.kind || "discussion")}"` +
-			` data-favorite-parent="${escapeHTML(about.parent || "")}"`;
+		const button = favoriteButtonHTML({
+			...about,
+			key: about.key || `${sourceID || ""}:${itemId}`,
+			source: sourceID,
+			id: itemId,
+		});
 
 		return `${between}
       |
-      <button class="item-action-link" type="button"
-      data-item-action="fave" data-item-action-source="${source}" data-item-action-id="${id}"${meta}>favorite</button>`;
+      ${button}`;
 	}
 
 	function favoriteKeysOf(entries) {
@@ -10451,12 +10466,14 @@ header {
 	cursor:default;
 }
 
-.item-action-link:enabled:focus-visible {
+.item-action-link:enabled:focus-visible,
+.page-header-watch:focus-visible {
 	text-decoration:underline;
 }
 
 @media (hover: hover) {
-	.item-action-link:enabled:hover {
+	.item-action-link:enabled:hover,
+	.page-header-watch:hover {
 		text-decoration:underline;
 	}
 }
@@ -10879,7 +10896,8 @@ header button svg {
 }
 
 .page-header-disclosure,
-.page-header-watch {
+.page-header-watch,
+.page-header-meta .item-action-link {
 	font:inherit;
 	color:inherit;
 	background:none;
@@ -15800,6 +15818,16 @@ ${settingsPanelHTML()}
 		const wrapper = document.createElement("div");
 
 		const single = stories.length < 2;
+		const pageURL = pageAddress();
+		const pageFavorite = single
+			? ""
+			: favoriteButtonHTML({
+					key: normalizeURL(pageURL) || "",
+					url: pageURL,
+					title: page || document.title || "",
+					site: hostLabel(pageURL),
+					kind: "discussion",
+				});
 
 		wrapper.className = single ? "page-header page-header-quiet" : "page-header";
 		wrapper.innerHTML = `
@@ -15810,7 +15838,9 @@ ${settingsPanelHTML()}
 		: ""
 }${
 	stories.length > 1
-		? `<button type="button" class="page-header-watch" aria-pressed="false">watch</button>`
+		? `<button type="button" class="page-header-watch" aria-pressed="false">watch</button>${
+			pageFavorite ? `<span class="page-header-sep">|</span>${pageFavorite}` : ""
+		}`
 		: ""
 }</div>
 <div class="source-strip${stories.length > 1 ? "" : " source-strip-single"}" id="source-strip">

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -7885,10 +7885,10 @@ button {
 			(sum, each) => sum + (each.descendants || 0),
 			0,
 		);
-		const totalText = escapeHTML(pluralize(totalComments, "comment"));
+		const totalWord = totalComments === 1 ? "comment" : "comments";
 
 		const commentTotal = `<a class="browse-comments-total" href="${escapeHTML(story.url)}"
-	title="Go to the page and read what was said about it">${totalText}<span class="browse-comments-floor" aria-hidden="true">+</span></a>`;
+	title="Go to the page and read what was said about it">${totalComments}<span class="browse-comments-floor" aria-hidden="true">+</span> ${totalWord}</a>`;
 
 		const actions =
 			!story.source || getSource(story.source)?.capabilities?.vote

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -9010,7 +9010,9 @@ button {
 	}
 
 	async function collectedNotesFor(page) {
-		return keptNotes(await load(noteStorageKey({ kind: page.kind, id: page.id }), null));
+		return keptNotes(
+			await load(page.key || noteStorageKey({ kind: page.kind, id: page.id }), null),
+		);
 	}
 
 	async function saveCollectedNotes(page, notes) {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -41,7 +41,6 @@
 // @exclude      https://*.instagram.com/*
 // @grant        GM.getValue
 // @grant        GM.setValue
-// @grant        GM.notification
 // @grant        GM.xmlHttpRequest
 // @grant        GM.getResourceText
 // @grant        unsafeWindow

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -11110,7 +11110,9 @@ header button svg {
 }
 
 @media (hover: hover) {
-	.settings-byline-action:hover {
+	.settings-byline-action:hover,
+	.settings-reset:hover,
+	.settings-credits a:hover {
 		color:var(--text);
 	}
 }

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -8590,6 +8590,8 @@ button {
 			? `${inPost}
 	<span class="item-age">${escapeHTML(timeAgo(story.time))}</span>
 	|
+	<button class="item-action-link browse-edit-note-link" type="button">edit</button>
+	|
 	<button class="item-action-link browse-delete-note-link" type="button">delete</button>`
 			: story.watchPlaceholder
 			? `<span class="item-age">watching since ${escapeHTML(timeAgo(story.time))}</span>
@@ -8863,16 +8865,16 @@ button {
 		);
 	}
 
-	function noteCollectionRow({ note, document }, list, onDelete) {
+	function noteCollectionRow({ note, document: page }, list, { onDelete, onEdit }) {
 		const row = collectionRow(
 			{
 				key: note.id,
 				kind: "noted",
-				url: document.url || "",
+				url: page.url || "",
 				title: favoriteExcerpt(note.text, FAVORITE_EXCERPT_CHARS),
-				context: document.title || document.url || document.id,
+				context: page.title || page.url || page.id,
 				time: note.edited || note.created || 0,
-				site: document.url ? hostLabel(document.url) : "",
+				site: page.url ? hostLabel(page.url) : "",
 			},
 			list,
 			null,
@@ -8882,24 +8884,72 @@ button {
 		const drop = row.querySelector(".browse-delete-note-link");
 
 		if (drop) {
-			drop.onclick = () => onDelete(document, note).catch(console.error);
+			drop.onclick = () => onDelete(page, note).catch(console.error);
+		}
+
+		const edit = row.querySelector(".browse-edit-note-link");
+
+		if (edit) {
+			edit.onclick = () => startCollectionNoteEdit(row, page, note, onEdit);
 		}
 
 		return row;
 	}
 
-	async function deleteCollectedNote(document, note) {
-		const ref = { kind: document.kind, id: document.id };
-		const notes = keptNotes(await load(noteStorageKey(ref), null));
+	function startCollectionNoteEdit(row, page, note, onEdit) {
+		const main = row.querySelector(".browse-main");
 
-		await saveNotes(
-			notes.filter((kept) => kept.id !== note.id),
-			ref,
-		);
+		if (!main || row.querySelector(".note-editor")) {
+			return;
+		}
 
-		if (sameURL(document.url || "", location.href)) {
+		const title = row.querySelector(".story-title");
+		const held = inlineNoteEditor(note, {
+			canAnchor: null,
+			onSave: (parsed) => onEdit(page, note, parsed).catch(console.error),
+			onClose: () => {
+				held.editor.remove();
+				title.hidden = false;
+			},
+		});
+
+		title.hidden = true;
+		title.after(held.editor);
+		held.field.focus();
+	}
+
+	async function collectedNotesFor(page) {
+		return keptNotes(await load(noteStorageKey({ kind: page.kind, id: page.id }), null));
+	}
+
+	async function saveCollectedNotes(page, notes) {
+		await saveNotes(notes, { kind: page.kind, id: page.id });
+
+		if (sameURL(page.url || "", location.href)) {
 			await reopenForNotes();
 		}
+	}
+
+	async function deleteCollectedNote(page, note) {
+		const notes = await collectedNotesFor(page);
+
+		await saveCollectedNotes(
+			page,
+			notes.filter((kept) => kept.id !== note.id),
+		);
+	}
+
+	async function updateCollectedNote(page, note, parsed) {
+		if (!parsed?.text && !parsed?.exact) {
+			return;
+		}
+
+		const notes = await collectedNotesFor(page);
+
+		await saveCollectedNotes(
+			page,
+			notes.map((kept) => (kept.id === note.id ? editedNote(kept, parsed) : kept)),
+		);
 	}
 
 	async function renderCollectionView(ui, list) {
@@ -8962,9 +9012,15 @@ button {
 			subhead(list, "noted");
 
 			for (const entry of noted) {
-				noteCollectionRow(entry, list, async (document, note) => {
-					await deleteCollectedNote(document, note);
-					await reload();
+				noteCollectionRow(entry, list, {
+					onDelete: async (page, note) => {
+						await deleteCollectedNote(page, note);
+						await reload();
+					},
+					onEdit: async (page, note, parsed) => {
+						await updateCollectedNote(page, note, parsed);
+						await reload();
+					},
 				});
 			}
 		}

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -8607,17 +8607,12 @@ button {
 	${commentTotal}`;
 
 		const row = document.createElement("div");
-		row.className = "story browse-row";
+		row.className =
+			"story browse-row" + (!rank && !options.bullet ? " browse-row-loose" : "");
 		row.dataset.storyId = String(story.id);
 		row.innerHTML = `
 	<div class="browse-rank">${
-		options.bullet
-			? options.fresh
-				? "&#9679;"
-				: "&#9675;"
-			: rank
-				? `${rank}.`
-				: "&#8226;"
+		options.bullet ? (options.fresh ? "&#9679;" : "&#9675;") : rank ? `${rank}.` : ""
 	}</div>
 	<div class="browse-main">
 	<div class="story-title">
@@ -8926,14 +8921,13 @@ button {
 			return;
 		}
 
-		let rank = 0;
 		const reload = () => renderCollectionView(ui, list);
 
 		if (saved.length) {
 			subhead(list, "favorite discussions");
 
 			for (const entry of saved) {
-				collectionRow(entry, list, (rank += 1), {
+				collectionRow(entry, list, null, {
 					unfavorite: entry.key,
 					reload,
 				});
@@ -10612,6 +10606,18 @@ header {
 	text-align:right;
 	color:var(--meta);
 	font-size:11px;
+}
+
+.browse-row-loose {
+	padding-bottom:0;
+}
+
+.browse-row-loose + .browse-row-loose {
+	margin-top:14px;
+}
+
+.browse-row-loose .browse-rank {
+	min-width:0;
 }
 
 .browse-main {


### PR DESCRIPTION
# v1.6.9

## Features
- You can now watch discussions and be notified when there are new comments
   - The queue subsection has been updated to show watched topics with indicators when they're updated
   - When you enable the feature you will be prompted if you also want system notifications (it still works if you deny)
- Added 'collection' to the Backchannel page so you can see all of your favorites (discussions and comments) and notes in one place
   - Favorites are stored locally, so that functionality is now available regardless of source
   - As part of this change, I'm removing the function where using favorites would send the request to Hacker News until I can build out a comprehensive solution that works across more/all sources
   - If you want to keep your Hacker News account synced with Backchannel, there is not a new checkbox in Settings > Sources to enable it

## Fixes
- Fixes to prevent site styling from breaking `line-height` in the sidebar
- Fixes for discussion source pill's styling being overwritten
- Fixes for quote detection when writing a note
- "69 comments +" → "69+ comments"
- Added animated transitions for subsections of Backchannel page
- Cleanup checkbox rendering
- Some adjustments to UI copy for clarity