### PR TITLE
v1.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,9 @@ use to detect updates, so every release bumps it.
 
   **Scroll the box out of sight and it follows you**, as a pill under the header.
   Pressing it opens the same box, still holding whatever you had half-written;
-  scrolling back puts it home.
+  scrolling back puts it home. Opened, the pill becomes that box's header — one
+  card rather than a bar floating above a separate panel — and it says **Keep a
+  note** where the discussion you are filtered to takes no replies.
 
   The box is one line tall until you write in it, then keeps a spare line below
   whatever you have written, and falls back to one line when you press away from
@@ -111,11 +113,14 @@ use to detect updates, so every release bumps it.
   give**, which is most of them on a phone. It was a checkbox that could be
   pressed and would then quietly un-tick itself.
 
-- **On a discussion from a single source the notepad sits with the piece**, after
-  the story and above the box you write a comment in, rather than at the very top
-  of the panel. A rule above it keeps it from reading as part of the story's own
-  text. On a page carrying several discussions it stays where it was, above them
-  all.
+- **The notepad sits under the box you write in**, between it and the comments,
+  and in the same place whether the page carries one discussion or several. Its
+  **NOTEPAD [–]** is a rule across the panel, like the **LIVE** line further
+  down.
+
+- **The box keeps clear of the rule under the header.** On a page carrying
+  several discussions it sat flush against it, which read as a line the box had
+  drawn for itself.
 
 - A note in the notepad is given the same room below it as above it. The last one
   used to sit on the rule beneath it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,8 +139,11 @@ use to detect updates, so every release bumps it.
 - **The notepad sits under the box you write in**, between it and the comments,
   and in the same place whether the page carries one discussion or several. Its
   **NOTEPAD [–]** is a rule across the panel, like the **LIVE** line further
-  down. Its closing rule is spaced the way the section is: 12px above and
-  12px below.
+  down, and its closing rule is spaced the way the section is.
+
+- **Folded, the notepad is one line and nothing else.** It kept its closing rule
+  and its full padding over an empty body, so **NOTEPAD [+]** sat in more than
+  three times the room it needed.
 
 - **The box keeps clear of the rule under the header.** On a page carrying
   several discussions it sat flush against it, which read as a line the box had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,8 @@ use to detect updates, so every release bumps it.
   to be a strip of pills that unfolded under the header. It drops from the
   **N discussions** link, lists **All sources** first, and then the discussions
   themselves — the ones running now under a **LIVE** heading, the rest below it,
-  each group busiest first, with its comment count on the right. Choosing one
+  each band split by source in alphabetical order and each source's own threads
+  busiest first, with its comment count on the right. Choosing one
   filters to it; choosing it again goes back to **All sources**, which is what
   pressing a lit pill used to do. A long blend scrolls inside the menu instead of
   wrapping into rows of pills.
@@ -96,6 +97,14 @@ use to detect updates, so every release bumps it.
   panels use — and scrolls when the blend is a long one. While that list is open
   the button carries the same pressed tint the header's icons do. Filtered to one
   discussion the button is plain **comment** and goes straight there.
+
+  That list is the same shape as the **N discussions** menu above it: the ones
+  running now under a **LIVE** heading and the rest below, each band split by
+  source — **Hacker News**, **Reddit** — in alphabetical order, each source's own
+  threads busiest first, and a comment count on every row. Two threads in one subreddit used to be two
+  rows both reading *r/live* with nothing to choose between them; they now carry
+  the month they were posted, as they already did elsewhere in the panel. One
+  press on a row posts there.
 
   **Scroll the box out of sight and it follows you**, as a pill under the header.
   Pressing it opens the same box, still holding whatever you had half-written;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,33 @@ use to detect updates, so every release bumps it.
   time.
 
 - **new first** is **prioritize unread**, and sits with the comments it reorders
-  rather than at the top of the panel.
+  rather than at the top of the panel. A pipe separates it from Sort.
+
+- **One box writes both a comment and a note.** It carries two buttons that say
+  what they do: a green **comment** that sends what you wrote down to the
+  discussion, and a grey **note** that keeps it up in your notepad. Which buttons
+  it shows depends on what is possible — a source that takes no replies offers
+  only the note, a reader with the notepad off gets only the comment, and where
+  neither applies there is no box at all. Filtering a blend down to a source that
+  takes no replies takes the green button away with it. The notepad no longer
+  carries its own **add a note**, and a note written in the box still anchors to
+  a passage you quoted, as before.
+
+  **A page carrying several discussions had no comment box at all** until now —
+  every composer sat inside a per-discussion block that a blend keeps hidden.
+  There, the green button asks which discussion you meant, from a list that drops
+  below it and scrolls when the blend is a long one; filtered to one, it goes
+  straight there.
+
+  **Scroll the box out of sight and it follows you**, as a pill under the header.
+  Pressing it opens the same box, still holding whatever you had half-written;
+  scrolling back puts it home.
+
+  The box is one line tall until you write in it, then keeps a spare line below
+  whatever you have written, and falls back to one line when you press away from
+  it; dragging its corner still sets a height of your own. Its two buttons and
+  **formatting** share a row inside the same border as the text. The notepad,
+  where you have written one, sits above the box, and the comments below it.
 
 - **Sort is offered on a single-source discussion too.** It used to appear only
   where more than one discussion was being blended, on the grounds that Best is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@ use to detect updates, so every release bumps it.
   *All of your favorited discussions, comments, and notes*. The line slides with
   the list when you move between the three.
 
+- **The discussions on a blended page are chosen from a menu**, where they used
+  to be a strip of pills that unfolded under the header. It drops from the
+  **N discussions** link, lists **All sources** first, and then the discussions
+  themselves — the ones running now under a **LIVE** heading, the rest below it,
+  each group busiest first, with its comment count on the right. Choosing one
+  filters to it; choosing it again goes back to **All sources**, which is what
+  pressing a lit pill used to do. A long blend scrolls inside the menu instead of
+  wrapping into rows of pills.
+
 - **The collection's sections fold.** *favorite discussions*, *favorite comments*
   and *notes* each carry a **[–]**, so a long collection can be read a part at a
   time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,10 @@ use to detect updates, so every release bumps it.
   several discussions it sat flush against it, which read as a line the box had
   drawn for itself.
 
+- **Neither button can be pressed until something is written.** They used to sit
+  at full strength over an empty field and answer a press with *Write something
+  first.*
+
 - **The button you pressed says what it is doing.** **comment** becomes
   *posting…* and **note** becomes *saving…*, each glimmering the way **loading
   comments…** does under the wordmark and in the button's own color; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,14 @@ use to detect updates, so every release bumps it.
   several discussions it sat flush against it, which read as a line the box had
   drawn for itself.
 
+- **The button you pressed says what it is doing.** **comment** becomes
+  *posting…* and **note** becomes *saving…*, each glimmering the way **loading
+  comments…** does under the wordmark and in the button's own color; then
+  *posted* or *saved* for a moment, then back. Neither button changes width
+  doing it. The status line beside **formatting** is left for what actually
+  needs saying — an error, or that a source is waiting for you to sign in — and
+  no longer keeps **Kept** on screen for the rest of the visit.
+
 - A note in the notepad is given the same room below it as above it. The last one
   used to sit on the rule beneath it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,169 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The version in `HNewhere.user.js`'s `@version` header is what userscript managers
 use to detect updates, so every release bumps it.
 
+## [1.6.11] — 2026-08-17
+
+### Added
+
+- **new first**, beside the Sort control at the top of a discussion. It appears
+  only when you are returning to something you have read before and there is
+  something new in it, and it is off until you press it. On a return visit the
+  comments posted since you were last here rise to the top, and the ones that
+  were already there follow. A live discussion still leads a quiet one, and the
+  order inside a thread is untouched. On a page with a single discussion — where
+  there is nothing to sort across and so no Sort control — it appears on its
+  own. (#112)
+
+### Changed
+
+- **The green mark clears once a comment has been on screen**, rather than only
+  after you scroll past it or press it. A comment you can see has been seen. It
+  takes about a second of being on screen, so a comment that flashes by while you
+  scroll somewhere else keeps its mark, and one below the fold keeps it until you
+  get there. This used to happen only on touch devices; it now happens
+  everywhere. (#112)
+
+- **Nothing is marked unread the first time you open a page.** A discussion you
+  have never read has nothing to be new against, and marking all of it green said
+  nothing. The visit is recorded, and the next time you open that page the mark
+  means what it says. (#112)
+
+- Changing the comment sort no longer clears every unread mark. The panel now
+  holds the time of your arrival for as long as you are on the page, instead of
+  re-reading a timestamp it had already moved forward.
+
+- **front pages**, **queue** and **collection** carry the dotted underline that
+  marks everything else you can press, and the one you are on is underlined
+  solid. They were told apart by color alone, which did not say they were
+  pressable.
+
+- **The front page loads as a skeleton of the page it is about to show**, rather
+  than a line of text where the first row goes. The line saying what is loading
+  now sits at the same left edge as the tabs and the blend note above it.
+
+- **Where a source has both arrows, the one you did not use dims** once a vote is
+  placed, instead of sitting at full strength beside the one you did. Hacker News
+  is unaffected — it replaces its arrow with **unvote**.
+
+- **Blended from …** is set at the size of the byline it sits above, rather than
+  a step larger.
+
+- The queue tab is **queue**, without a count after it. What is unread is already
+  said by the rows themselves.
+
+- **The queue and the collection each say what they hold**, the way the front page
+  says what it is blended from: *Discussions you've queued or are watching*, and
+  *All of your favorited discussions, comments, and notes*. The line slides with
+  the list when you move between the three.
+
+- **The collection's sections fold.** *favorite discussions*, *favorite comments*
+  and *notes* each carry a **[–]**, so a long collection can be read a part at a
+  time.
+
+- **new first** is **prioritize unread**, and sits with the comments it reorders
+  rather than at the top of the panel.
+
+- **Collapsing a comment takes its indent guide with it** rather than leaving a
+  stub of it behind holding the row open. Expanding draws the guide back down
+  from the top.
+
+- **The notifications option is hidden where the browser has no notifications to
+  give**, which is most of them on a phone. It was a checkbox that could be
+  pressed and would then quietly un-tick itself.
+
+- **On a discussion from a single source the notepad sits with the piece**, after
+  the story and above the box you write a comment in, rather than at the very top
+  of the panel. A rule above it keeps it from reading as part of the story's own
+  text. On a page carrying several discussions it stays where it was, above them
+  all.
+
+- A note in the notepad is given the same room below it as above it. The last one
+  used to sit on the rule beneath it.
+
+### Fixed
+
+- **A Hacker News action on a phone reported a blocked popup and left nowhere to
+  go.** Voting opened its window one step after the press rather than during it,
+  which is when browsers stop allowing it — measured across three engines, only
+  the synchronous case keeps the activation a popup blocker looks for. The window
+  is now opened while the press is still running. If it is blocked anyway, the
+  message no longer points at a setting that iOS does not have: it offers the
+  address, and pressing it does the same thing in a tab. (#109)
+
+- **A link underneath a highlight could not be pressed.** Each highlight was a
+  button laid over the article, so it took the press from anything beneath it.
+  The highlight is now drawn whole and made pressable only where nothing else is,
+  which leaves links, buttons and fields to the page. (#110)
+
+- **The panel's left edges did not line up.** The wordmark sits 8px further in
+  than everything below it, and only some of the things below it made up the
+  difference. A discussion's title and byline, **NOTEPAD**, the **Sort** row, and
+  the numbered rows on the front page and in the queue all start on the wordmark's
+  edge now. The numbers themselves were also set right-aligned in their column,
+  which pushed them off that edge whatever the column did; they read from the left.
+
+- **The LIVE bookend and the rule under a blended discussion's byline** started
+  8px left of everything else, for the same reason the rest did.
+
+- **The notepad's notes, and the box you write one in, started on the panel's
+  edge** while the NOTEPAD mark started on the wordmark's. They start together.
+
+- **The box you write a comment in, and the numbers on the front page and in the
+  queue**, both start on that same edge now. The numbers' column also held room
+  for four digits where two was the most it ever needed, which left the number
+  stranded away from the title beside it.
+
+- **The rule above the notepad ran wider than the one below it**, and **add a
+  note** carried no underline to say it could be pressed. The two rules match,
+  and it does.
+
+- **queue** and **collection** were losing their dotted underline to the
+  `overflow:hidden` that lets them slide open. They keep it.
+
+- **Returning to the front page from another tab showed the old rows** until the
+  new ones arrived, with no sign anything was loading. The list is cleared when
+  the tab changes, so the skeleton appears.
+
+- **A discussion's title was set larger than the header it stands in for**, so
+  narrowing a blended page to a single source made the title jump a size. Both
+  are set the same now.
+
+- **A source that cannot vote no longer holds a column open for arrows it will
+  never have.** Filtering a blended page down to Bluesky, Lemmy or Wikipedia used
+  to leave the title indented past an empty gutter; it starts where the rest of
+  the panel starts.
+
+- **A story's vote arrows sat on its title.** The column holding them was 14px
+  wide and the arrow inside it 10px, drawn centred — so it overhung its own cell
+  and touched the words. Both a story's arrows and a comment's now use one
+  column, so a title clears them by the same margin a comment's text does.
+
+- **A settings hint started two pixels left of the label it belongs to.** The
+  label clears a 15px box and an 8px gap, and the hint was indented 21px rather
+  than 23. Sub-options were out by the same two.
+
+- **The line down the left of a comment went missing on about half of them, with
+  no pattern to it.** The line hangs below the vote arrows and takes whatever
+  height is left over. A two-arrow pair is 22px, and with the padding above and
+  the gap below that is 26px — exactly the height of a one-line comment, leaving
+  the line nothing at all. Which comments lost it therefore depended on how many
+  arrows their source draws and how short they happened to be. Measured on a real
+  thread: 85 of 182 comments had no line. The line now has a minimum length, and
+  short comments give it the few pixels it needs.
+
+- **Vote arrows never finished loading on a page carrying more than one
+  source.** A comment was told to expect arrows whenever *any* source in the
+  panel could vote, but arrows are fetched one discussion at a time and only for
+  the sources that have them. Comments from Bluesky, Lobsters, Lemmy, Wikipedia
+  or Hypothes.is were left holding a placeholder nothing was ever going to fill.
+  A comment now expects arrows only where its own source can vote. The gutter is
+  still held across the whole thread, so the comment guides stay lined up.
+
+- **Highlights stayed where the text used to be** when the page reflowed —
+  changing text size, a font arriving late, anything above them growing. They
+  only followed the window being resized, so scrolling a page with images loading
+  appeared to fix them. They now follow the article itself. (#111)
+
 ## [1.6.9] — 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ use to detect updates, so every release bumps it.
   *All of your favorited discussions, comments, and notes*. The line slides with
   the list when you move between the three.
 
+- **Both dropdowns close on a press outside them**, the way the header's hide
+  menu already did — the discussions menu and the one the comment button opens.
+
 - **The discussions on a blended page are chosen from a menu**, where they used
   to be a strip of pills that unfolded under the header. It drops from the
   **N discussions** link, lists **All sources** first, and then the discussions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,22 @@ use to detect updates, so every release bumps it.
 - A note in the notepad is given the same room below it as above it. The last one
   used to sit on the rule beneath it.
 
+- **The notepad folds with a [–]**, the mark everything else in the panel that
+  folds already carries. Folded, it is a **[+]**.
+
+- **A note carries no author and no indent guide.** Every note in the notepad is
+  yours, so there was nothing for the name to tell you apart from and nothing to
+  nest under — only when it was written, and **edit** / **delete**.
+
+- **Delete the last note on a discussion and the notepad folds away**, instead of
+  leaving its heading and rule standing over nothing.
+
 ### Fixed
+
+- **Saving a note redrew the whole discussion.** On a page whose notepad was
+  still empty there was nothing on screen to add the note to, so the panel
+  rebuilt the page from scratch. It now puts the notepad in place and adds the
+  note to it, the way every note after the first was already handled.
 
 - **A Hacker News action on a phone reported a blocked popup and left nowhere to
   go.** Voting opened its window one step after the press rather than during it,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,11 +109,11 @@ use to detect updates, so every release bumps it.
   the month they were posted, as they already did elsewhere in the panel. One
   press on a row posts there.
 
-  **Scroll the box out of sight and it follows you**, as a pill under the header.
-  Pressing it opens the same box, still holding whatever you had half-written;
-  scrolling back puts it home. Opened, the pill becomes that box's header — one
-  card rather than a bar floating above a separate panel — and it says **Keep a
-  note** where the discussion you are filtered to takes no replies.
+  **The header carries a comment control**, a speech bubble to the left of the
+  hide menu, and pressing it drops the same box under the header — still holding
+  whatever you had half-written, wherever you had scrolled to. A press outside
+  puts it back where it lives. It reads **Keep a note** where the discussion you
+  are filtered to takes no replies.
 
   The box is one line tall until you write in it, then keeps a spare line below
   whatever you have written, and falls back to one line when you press away from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,9 +82,11 @@ use to detect updates, so every release bumps it.
 
   **A page carrying several discussions had no comment box at all** until now —
   every composer sat inside a per-discussion block that a blend keeps hidden.
-  There, the green button asks which discussion you meant, from a list that drops
-  below it and scrolls when the blend is a long one; filtered to one, it goes
-  straight there.
+  There, the green button reads **comment…** and asks which discussion you meant,
+  from a list that drops just under it — at the same offset the header's own
+  panels use — and scrolls when the blend is a long one. While that list is open
+  the button carries the same pressed tint the header's icons do. Filtered to one
+  discussion the button is plain **comment** and goes straight there.
 
   **Scroll the box out of sight and it follows you**, as a pill under the header.
   Pressing it opens the same box, still holding whatever you had half-written;
@@ -116,7 +118,8 @@ use to detect updates, so every release bumps it.
 - **The notepad sits under the box you write in**, between it and the comments,
   and in the same place whether the page carries one discussion or several. Its
   **NOTEPAD [–]** is a rule across the panel, like the **LIVE** line further
-  down.
+  down. Its closing rule is spaced the way the section is: 12px above and
+  12px below.
 
 - **The box keeps clear of the rule under the header.** On a page carrying
   several discussions it sat flush against it, which read as a line the box had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@ use to detect updates, so every release bumps it.
 - **new first** is **prioritize unread**, and sits with the comments it reorders
   rather than at the top of the panel.
 
+- **Sort is offered on a single-source discussion too.** It used to appear only
+  where more than one discussion was being blended, on the grounds that Best is
+  a site's own order and there is nothing to choose. That holds for Best and not
+  for the other two: Newest and Oldest reorder a single discussion from times
+  the panel already has. Best is still there, and still means the order the site
+  gave.
+
 - **Collapsing a comment takes its indent guide with it** rather than leaving a
   stub of it behind holding the row open. Expanding draws the guide back down
   from the top.

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -13242,6 +13242,8 @@ ${[
 			});
 		}
 
+		shadow.addEventListener("click", (event) => closeMenusOutside(shadow, event));
+
 		const notesExport = shadow.querySelector("#settings-notes-export");
 		const notesCount = shadow.querySelector("#settings-notes-count");
 
@@ -15618,6 +15620,53 @@ ${settingsPanelHTML()}
 		return canComment ? "Add a comment" : "Keep a note";
 	}
 
+	function closeSourceMenu(shadow) {
+		const menu = shadow.querySelector(".source-menu");
+
+		menu?.classList.add("hidden");
+		shadow
+			.querySelector(".page-header-disclosure")
+			?.setAttribute("aria-expanded", "false");
+	}
+
+	function closeMenusOutside(shadow, event) {
+		const path = event.composedPath();
+		const outside = (node) => node && !path.includes(node);
+		const menu = shadow.querySelector(".source-menu");
+
+		if (
+			menu &&
+			outside(menu) &&
+			outside(shadow.querySelector(".page-header-disclosure"))
+		) {
+			closeSourceMenu(shadow);
+		}
+
+		const dock = shadow.querySelector("#compose-dock");
+
+		if (
+			dock &&
+			!dock.hidden &&
+			outside(dock) &&
+			outside(shadow.querySelector("#comment-toggle"))
+		) {
+			dock.querySelector(".compose-box")?._hnewhereDock?.undock();
+		}
+
+		for (const box of shadow.querySelectorAll(".comment-composer")) {
+			const targets = box.querySelector(".compose-targets");
+
+			if (
+				targets &&
+				!targets.classList.contains("hidden") &&
+				outside(targets) &&
+				outside(box.querySelector(".compose-send-comment"))
+			) {
+				closeComposeTargets(box);
+			}
+		}
+	}
+
 	function closeComposeTargets(box) {
 		const button = box.querySelector(".compose-send-comment");
 
@@ -17657,8 +17706,13 @@ ${settingsPanelHTML()}
 		const menu = wrapper.querySelector(".source-menu");
 
 		const setMenuOpen = (open) => {
-			menu.classList.toggle("hidden", !open);
-			disclosure.setAttribute("aria-expanded", open ? "true" : "false");
+			if (!open) {
+				closeSourceMenu(wrapper.getRootNode());
+				return;
+			}
+
+			menu.classList.remove("hidden");
+			disclosure.setAttribute("aria-expanded", "true");
 		};
 
 		setMenuOpen(false);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -14251,6 +14251,10 @@ ${SUBMIT_FORM_CSS}
 	width:var(--vote-column);
 }
 
+.story-vote-none {
+	width:8px;
+}
+
 .story-votelinks {
 	text-align:center;
 }
@@ -14524,7 +14528,7 @@ blockquote.comment-quote-redundant {
 }
 
 .story-title {
-	font-size:15px;
+	font-size:13px;
 	line-height:1.25;
 }
 
@@ -15096,7 +15100,7 @@ ${settingsPanelHTML()}
 	${
 		showTitle
 			? `<tr>
-	<td class="story-votelinks">
+	<td class="story-votelinks${canVote ? "" : " story-vote-none"}">
 	${voteControlsHTML}
 	</td>
 	<td class="story-title-cell">
@@ -15116,7 +15120,7 @@ ${settingsPanelHTML()}
 			: ""
 	}
 	<tr>
-	<td class="${showTitle ? "story-votespacer" : "story-votelinks story-votelinks-inline"}">${showTitle ? "" : voteControlsHTML}</td>
+	<td class="${showTitle ? "story-votespacer" : "story-votelinks story-votelinks-inline"}${canVote ? "" : " story-vote-none"}">${showTitle ? "" : voteControlsHTML}</td>
 	<td class="story-body-cell">
 	<div class="story-meta">
 	${

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -15718,12 +15718,15 @@ ${settingsPanelHTML()}
 		const capabilities = getSource(comment.source)?.capabilities || {};
 		const isLocalSource = Boolean(comment.local);
 		const threadCanVote = renderedSourcesCanVote();
+		const voteSourceID = String(comment.source || "hn");
+		const commentCanVote =
+			!isLocalSource && Boolean(getSource(voteSourceID)?.capabilities.vote);
 
 		div.innerHTML = `
       <div class="comment-layout">
       <span class="comment-vote-slot${threadCanVote && !isLocalSource ? "" : " comment-vote-slot-empty"}">
-      <span class="comment-vote-controls vote-controls hidden${threadCanVote && !isLocalSource ? " vote-controls-expected" : ""}"
-      data-hn-vote-source="${escapeHTML(String(comment.source || "hn"))}"
+      <span class="comment-vote-controls vote-controls hidden${commentCanVote ? " vote-controls-expected" : ""}"
+      data-hn-vote-source="${escapeHTML(voteSourceID)}"
       data-hn-vote-story-id="${escapeHTML(String(storyID))}"
       data-hn-vote-item-id="${escapeHTML(commentID)}"></span>
       </span>

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -8789,6 +8789,7 @@ button {
 
 	function slideBrowseList(ui, direction, render) {
 		const list = ui?.shadow?.querySelector("#browse-list");
+		const note = ui?.shadow?.querySelector("#browse-blend-note");
 
 		if (!list || prefersReducedMotion()) {
 			render().catch(console.error);
@@ -8802,13 +8803,15 @@ button {
 		const out = direction > 0 ? "slide-out-left" : "slide-out-right";
 		const enter = direction > 0 ? "slide-in-right" : "slide-in-left";
 
-		list.classList.remove(
-			"slide-in-left",
-			"slide-in-right",
-			"slide-out-left",
-			"slide-out-right",
-		);
-		list.classList.add(out);
+		for (const element of [list, note]) {
+			element?.classList.remove(
+				"slide-in-left",
+				"slide-in-right",
+				"slide-out-left",
+				"slide-out-right",
+			);
+			element?.classList.add(out);
+		}
 
 		list._hnewhereSlideTimer = window.setTimeout(async () => {
 			try {
@@ -8817,11 +8820,17 @@ button {
 				console.error(error);
 			}
 
-			list.classList.remove(out);
-			list.classList.add(enter);
+			for (const element of [list, note]) {
+				element?.classList.remove(out);
+				element?.classList.add(enter);
+			}
 
 			requestAnimationFrame(() => {
-				requestAnimationFrame(() => list.classList.remove(enter));
+				requestAnimationFrame(() => {
+					for (const element of [list, note]) {
+						element?.classList.remove(enter);
+					}
+				});
 			});
 
 			list._hnewhereSlideTimer = null;
@@ -9417,7 +9426,7 @@ button {
 		paintBrowseTab(
 			tab,
 			queueHasItems,
-			unread ? `queue (${unread})` : "queue",
+			"queue",
 			"--queue-tab-width",
 			"has-queue",
 		);
@@ -9831,25 +9840,64 @@ button {
 		}
 	}
 
-	function setBlendNote(ui, sources) {
+	const QUEUE_NOTE = "Discussions you've queued or are watching";
+
+	const COLLECTION_NOTE =
+		"All of your favorited discussions, comments, and notes";
+
+	function setBrowseNote(ui, text) {
 		const note = ui?.shadow?.querySelector("#browse-blend-note");
 
 		if (!note) {
 			return;
 		}
 
-		note.hidden = sources.length < 2;
+		note.hidden = !text;
 
-		if (!note.hidden) {
-			note.textContent =
-				"Blended from " +
-				joinWithAnd(sources.map((id) => getSource(id)?.label || id));
+		if (text) {
+			note.textContent = text;
 		}
+	}
+
+	function setBlendNote(ui, sources) {
+		setBrowseNote(
+			ui,
+			sources.length < 2
+				? ""
+				: "Blended from " +
+						joinWithAnd(sources.map((id) => getSource(id)?.label || id)),
+		);
+	}
+
+	const BROWSE_SKELETON_WIDTHS = ["92%", "74%", "86%", "63%", "81%", "70%", "88%", "58%"];
+
+	function renderBrowseSkeleton(list, label) {
+		const wrap = document.createElement("div");
+
+		wrap.className = "browse-skeleton";
+
+		const note = document.createElement("div");
+
+		note.className = "browse-skeleton-label";
+		note.textContent = label;
+		wrap.appendChild(note);
+
+		for (const width of BROWSE_SKELETON_WIDTHS) {
+			const row = document.createElement("div");
+
+			row.className = "browse-skeleton-row";
+			row.style.setProperty("--skeleton-title", width);
+			row.innerHTML = `<span class="browse-skeleton-rank"></span>
+<span class="browse-skeleton-lines"><span class="browse-skeleton-bar"></span><span class="browse-skeleton-bar"></span></span>`;
+			wrap.appendChild(row);
+		}
+
+		list.replaceChildren(wrap);
 	}
 
 	async function renderFrontPageView(ui, list) {
 		if (!list.childElementCount) {
-			list.textContent = "Loading front pages…";
+			renderBrowseSkeleton(list, "Loading front pages…");
 		}
 
 		const requested = browsePage;
@@ -9930,14 +9978,19 @@ button {
 
 		refreshQueueCount(ui.shadow);
 
+		if (list.dataset.browseTab !== browseTab) {
+			list.replaceChildren();
+			list.dataset.browseTab = browseTab;
+		}
+
 		if (browseTab === "queue") {
-			setBlendNote(ui, []);
+			setBrowseNote(ui, QUEUE_NOTE);
 			await renderQueueView(ui, list);
 			return;
 		}
 
 		if (browseTab === "collection") {
-			setBlendNote(ui, []);
+			setBrowseNote(ui, COLLECTION_NOTE);
 			await renderCollectionView(ui, list);
 			return;
 		}
@@ -10814,27 +10867,33 @@ header {
 	transition:opacity .16s ease, transform .16s ease;
 }
 
-#browse-list.slide-out-left {
+#browse-list.slide-out-left,
+#browse-blend-note.slide-out-left {
 	opacity:0;
 	transform:translateX(-14px);
 }
 
-#browse-list.slide-out-right {
+#browse-list.slide-out-right,
+#browse-blend-note.slide-out-right {
 	opacity:0;
 	transform:translateX(14px);
 }
 
 #browse-list.slide-in-right,
-#browse-list.slide-in-left {
+#browse-list.slide-in-left,
+#browse-blend-note.slide-in-right,
+#browse-blend-note.slide-in-left {
 	transition:none;
 	opacity:0;
 }
 
-#browse-list.slide-in-right {
+#browse-list.slide-in-right,
+#browse-blend-note.slide-in-right {
 	transform:translateX(14px);
 }
 
-#browse-list.slide-in-left {
+#browse-list.slide-in-left,
+#browse-blend-note.slide-in-left {
 	transform:translateX(-14px);
 }
 
@@ -10881,6 +10940,7 @@ header {
 
 #browse-tab-front::after {
 	content:none;
+	display:inline-block;
 	margin:0 .35em;
 	color:var(--meta);
 }
@@ -10942,22 +11002,24 @@ header {
 
 .browse-tab {
 	border:0;
-	padding:0;
+	padding:0 0 3px;
 	background:none;
 	color:var(--meta);
 	cursor:pointer;
 	font-family:inherit;
 	font-size:inherit;
+	text-decoration:underline dotted;
+	text-underline-offset:2px;
 }
 
 .browse-tab.is-current {
 	color:var(--text);
+	text-decoration:underline;
 }
 
 @media (hover: hover) {
 	.browse-tab:not(.is-current):hover {
 		text-decoration:underline;
-		text-underline-offset:2px;
 	}
 }
 
@@ -10999,8 +11061,77 @@ header {
 .browse-blend-note {
 	margin:-7px 0 10px 8px;
 	color:var(--meta);
-	font-size:11px;
+	font-size:10px;
 	font-family:Verdana, Geneva, sans-serif;
+	transition:opacity .16s ease, transform .16s ease;
+}
+
+.browse-skeleton {
+	margin-left:8px;
+}
+
+.browse-skeleton-label {
+	margin:-7px 0 12px;
+	color:var(--meta);
+	font-size:10px;
+	font-family:Verdana, Geneva, sans-serif;
+}
+
+.browse-skeleton-row {
+	display:flex;
+	align-items:flex-start;
+	gap:8px;
+	margin-bottom:14px;
+}
+
+.browse-skeleton-lines {
+	flex:1 1 auto;
+	min-width:0;
+}
+
+.browse-skeleton-rank,
+.browse-skeleton-bar {
+	display:block;
+	border-radius:2px;
+	background:linear-gradient(
+		90deg,
+		var(--hover-tint) 0%,
+		var(--hover-tint) 40%,
+		var(--active-tint) 50%,
+		var(--hover-tint) 60%,
+		var(--hover-tint) 100%
+	);
+	background-size:220% 100%;
+	animation:hnewhere-browse-skeleton 1.6s linear infinite;
+}
+
+.browse-skeleton-rank {
+	flex:0 0 20px;
+	height:9px;
+	margin-top:2px;
+}
+
+.browse-skeleton-bar {
+	height:11px;
+	width:var(--skeleton-title, 80%);
+}
+
+.browse-skeleton-bar + .browse-skeleton-bar {
+	margin-top:6px;
+	height:9px;
+	width:38%;
+}
+
+@keyframes hnewhere-browse-skeleton {
+	from { background-position:120% 0; }
+	to { background-position:-20% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.browse-skeleton-rank,
+	.browse-skeleton-bar {
+		animation:none;
+	}
 }
 
 .browse-blend-note[hidden] {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -2950,23 +2950,44 @@
 		return (disambiguating && story?.title) || page;
 	}
 
-	function sourceMenuGroups(stories, liveKeys) {
+	function sourceMenuGroups(stories, liveKeys, labelFor = (id) => id) {
 		const live = new Set(liveKeys || []);
-		const busiest = (list) =>
-			[...list].sort((a, b) => (b.commentCount ?? 0) - (a.commentCount ?? 0));
-		const running = busiest((stories || []).filter((story) => live.has(story.key)));
-		const rest = busiest((stories || []).filter((story) => !live.has(story.key)));
 
-		if (!running.length) {
-			return rest.length ? [{ live: false, stories: rest }] : [];
+		const bySource = (list) => {
+			const held = new Map();
+
+			for (const story of list) {
+				if (!held.has(story.source)) {
+					held.set(story.source, []);
+				}
+
+				held.get(story.source).push(story);
+			}
+
+			return [...held]
+				.map(([id, own]) => ({
+					id,
+					label: labelFor(id) || id,
+					stories: own.sort(
+						(a, b) => (b.commentCount ?? 0) - (a.commentCount ?? 0),
+					),
+				}))
+				.sort((a, b) => a.label.localeCompare(b.label));
+		};
+
+		const band = (running) =>
+			(stories || []).filter((story) => live.has(story.key) === running);
+		const groups = [];
+
+		for (const running of [true, false]) {
+			const own = band(running);
+
+			if (own.length) {
+				groups.push({ live: running, sources: bySource(own) });
+			}
 		}
 
-		return rest.length
-			? [
-					{ live: true, stories: running },
-					{ live: false, stories: rest },
-				]
-			: [{ live: true, stories: running }];
+		return groups;
 	}
 
 	function newestCommentTime(comments, discussionKey) {
@@ -11698,18 +11719,31 @@ header button svg {
 	display:none;
 }
 
-.source-menu-group + .source-menu-group {
+.choice-group + .choice-group {
 	margin-top:8px;
 	padding-top:8px;
 	border-top:1px solid var(--surface-divider);
 }
 
-.source-menu-head {
+.choice-head {
 	margin-bottom:6px;
 }
 
-.source-menu-head .live-pill {
+.choice-head .live-pill {
 	margin-left:0;
+}
+
+.choice-sub + .choice-sub {
+	margin-top:7px;
+}
+
+.choice-sub-head {
+	margin:0 0 3px 2px;
+	color:var(--muted);
+	font-size:10px;
+	font-weight:600;
+	letter-spacing:.04em;
+	text-transform:uppercase;
 }
 
 .source-menu-option {
@@ -11744,21 +11778,21 @@ header button svg {
 	background:var(--accent);
 }
 
-.source-menu-label {
+.choice-label {
 	min-width:0;
 	overflow:hidden;
 	text-overflow:ellipsis;
 	white-space:nowrap;
 }
 
-.source-menu-count {
+.choice-count {
 	margin-left:auto;
 	padding-left:8px;
 	color:var(--muted);
 	font-variant-numeric:tabular-nums;
 }
 
-.source-menu-option-active .source-menu-label {
+.source-menu-option-active .choice-label {
 	font-weight:600;
 }
 
@@ -14836,6 +14870,7 @@ blockquote.comment-quote-redundant {
 	display:flex;
 	flex-direction:column;
 	min-width:132px;
+	max-width:270px;
 	padding:4px;
 	border:1px solid var(--surface-border);
 	border-radius:6px;
@@ -14848,7 +14883,11 @@ blockquote.comment-quote-redundant {
 }
 
 .compose-target {
-	padding:5px 8px;
+	display:flex;
+	align-items:center;
+	gap:8px;
+	width:100%;
+	padding:4px 6px;
 	border:0;
 	border-radius:4px;
 	background:none;
@@ -14857,6 +14896,10 @@ blockquote.comment-quote-redundant {
 	font-size:12px;
 	text-align:left;
 	cursor:pointer;
+}
+
+.compose-target + .compose-target {
+	margin-top:2px;
 }
 
 @media (hover: hover) {
@@ -15723,7 +15766,26 @@ ${settingsPanelHTML()}
 			commentButton.setAttribute("aria-expanded", "true");
 		};
 
+		let offered = [];
+
 		if (canComment) {
+			menu.addEventListener("click", (event) => {
+				const choice = event.target.closest(".compose-target");
+				const story = offered.find(
+					(candidate) => candidate.key === choice?.dataset.discussionKey,
+				);
+
+				if (!story) {
+					return;
+				}
+
+				closeMenu();
+				box._hnewhereDock?.undock();
+				held
+					.send({ source: story.source, storyID: story.id })
+					.finally(() => syncComposeSendable(box));
+			});
+
 			commentButton.onclick = () => {
 				const targets = replyTargets(stories);
 
@@ -15745,24 +15807,11 @@ ${settingsPanelHTML()}
 					return;
 				}
 
-				menu.replaceChildren(
-					...targets.map((story) => {
-						const choice = document.createElement("button");
-
-						choice.type = "button";
-						choice.className = "compose-target";
-						choice.textContent =
-							story.baseLabel || story.label || getSource(story.source)?.label || story.source;
-						choice.onclick = () => {
-							closeMenu();
-							box._hnewhereDock?.undock();
-							held
-								.send({ source: story.source, storyID: story.id })
-								.finally(() => syncComposeSendable(box));
-						};
-
-						return choice;
-					}),
+				offered = targets;
+				menu.innerHTML = discussionChoiceGroupsHTML(
+					targets,
+					(story, about) =>
+						`<button type="button" class="compose-target" data-discussion-key="${escapeHTML(story.key)}">${discussionChoiceHTML("", about)}</button>`,
 				);
 				openMenu();
 			};
@@ -17307,9 +17356,9 @@ ${settingsPanelHTML()}
 				}
 			}
 
-			for (const option of body.querySelectorAll(".source-menu-option")) {
-				if (option.dataset.discussionKey === story.key) {
-					const shown = option.querySelector(".source-menu-count");
+			for (const row of body.querySelectorAll("[data-discussion-key]")) {
+				if (row.dataset.discussionKey === story.key) {
+					const shown = row.querySelector(".choice-count");
 
 					if (shown) {
 						shown.textContent = String(count);
@@ -17717,39 +17766,63 @@ ${settingsPanelHTML()}
 
 	let sourceMenuSeq = 0;
 
+	function discussionChoiceLabel(story) {
+		return (
+			story.label || story.baseLabel || getSource(story.source)?.label || story.source
+		);
+	}
+
+	function discussionChoiceHTML(inner, { label, count = null, live = false }) {
+		return `${inner}<span class="choice-label">${escapeHTML(label)}</span>${
+			count === null ? "" : `<span class="choice-count">${escapeHTML(String(count))}</span>`
+		}${live ? `<span class="live-pill">LIVE</span>` : ""}`;
+	}
+
+	function discussionChoiceGroupsHTML(stories, row) {
+		const groups = sourceMenuGroups(
+			stories,
+			liveDiscussions.keys(),
+			(id) => getSource(id)?.label,
+		);
+
+		return groups
+			.map(
+				(group) => `<div class="choice-group">${
+					group.live && groups.length > 1
+						? `<div class="choice-head"><span class="live-pill">LIVE</span></div>`
+						: ""
+				}${group.sources
+					.map(
+						(source) => `<div class="choice-sub">${
+							group.sources.length > 1
+								? `<div class="choice-sub-head">${escapeHTML(source.label)}</div>`
+								: ""
+						}${source.stories
+							.map((story) =>
+								row(story, {
+									label: discussionChoiceLabel(story),
+									count: story.commentCount ?? 0,
+									live: group.live && groups.length === 1,
+								}),
+							)
+							.join("")}</div>`,
+					)
+					.join("")}</div>`,
+			)
+			.join("");
+	}
+
 	function sourceMenuHTML(stories) {
 		const name = `source-menu-${(sourceMenuSeq += 1)}`;
-		const groups = sourceMenuGroups(stories, liveDiscussions.keys());
-		const option = (key, label, count, live) => `
-<label class="settings-option source-menu-option"${key ? ` data-discussion-key="${escapeHTML(key)}"` : ""}>
-<input type="radio" name="${name}"${key ? "" : " checked"}>
-<span class="source-menu-label">${escapeHTML(label)}</span>${
-	count === null
-		? ""
-		: `<span class="source-menu-count">${escapeHTML(String(count))}</span>`
-}${live ? `<span class="live-pill">LIVE</span>` : ""}
-</label>`;
+		const option = (key, about) => `
+<label class="settings-option source-menu-option"${key ? ` data-discussion-key="${escapeHTML(key)}"` : ""}>${discussionChoiceHTML(
+			`<input type="radio" name="${name}"${key ? "" : " checked"}>`,
+			about,
+		)}</label>`;
 
 		return `<div class="source-menu hidden" id="source-menu" role="menu">
-<div class="source-menu-group">${option("", "All sources", null, false)}</div>
-${groups
-	.map(
-		(group) => `<div class="source-menu-group">${
-			group.live && groups.length > 1
-				? `<div class="source-menu-head"><span class="live-pill">LIVE</span></div>`
-				: ""
-		}${group.stories
-			.map((story) =>
-				option(
-					story.key,
-					(liveDiscussions.has(story.key) ? story.baseLabel || story.label : story.label) || story.source,
-					story.commentCount ?? 0,
-					group.live && groups.length === 1,
-				),
-			)
-			.join("")}</div>`,
-	)
-	.join("")}
+<div class="choice-group">${option("", { label: "All sources" })}</div>
+${discussionChoiceGroupsHTML(stories, (story, about) => option(story.key, about))}
 </div>`;
 	}
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -13847,7 +13847,7 @@ ${SUBMIT_FORM_CSS}
 }
 
 .notepad-rule-close {
-	padding-top:8px;
+	padding-top:12px;
 }
 
 .notepad-mark {
@@ -14669,6 +14669,7 @@ blockquote.comment-quote-redundant {
 }
 
 .compose-send-row {
+	position:relative;
 	display:inline-flex;
 	gap:6px;
 	margin-left:auto;
@@ -14749,6 +14750,10 @@ blockquote.comment-quote-redundant {
 .compose-send-comment {
 	color:var(--accent-ink);
 	background:var(--accent);
+}
+
+.compose-send.is-open {
+	background-image:linear-gradient(var(--active-tint), var(--active-tint));
 }
 
 @media (hover: hover) {
@@ -15511,6 +15516,14 @@ ${settingsPanelHTML()}
 		return canComment ? "Add a comment" : "Keep a note";
 	}
 
+	function closeComposeTargets(box) {
+		const button = box.querySelector(".compose-send-comment");
+
+		box.querySelector(".compose-targets")?.classList.add("hidden");
+		button?.classList.remove("is-open");
+		button?.setAttribute("aria-expanded", "false");
+	}
+
 	function syncComposeBox() {
 		const box =
 			sidebarUI?.body?.querySelector(".compose-box") ||
@@ -15524,15 +15537,21 @@ ${settingsPanelHTML()}
 		const targets = replyTargets();
 		const canNote = Boolean(box.querySelector(".compose-send-note"));
 		const pill = sidebarUI.shadow.querySelector("#compose-dock-pill");
+		const word = targets.length > 1 ? "comment\u2026" : "comment";
 
 		button.hidden = targets.length === 0;
+		composeSendRest.set(button, word);
+
+		if (!button.dataset.sending) {
+			composeSendLabel(button).textContent = word;
+		}
 
 		if (pill) {
 			pill.textContent = composeDockLabel(targets.length > 0);
 		}
 
 		if (!targets.length) {
-			box.querySelector(".compose-targets")?.classList.add("hidden");
+			closeComposeTargets(box);
 		}
 
 		const field = box.querySelector(".composer-text");
@@ -15623,11 +15642,16 @@ ${settingsPanelHTML()}
 			status.textContent = message || "";
 		};
 
-		const closeMenu = () => menu.classList.add("hidden");
+		const commentButton = box.querySelector(".compose-send-comment");
+		const closeMenu = () => closeComposeTargets(box);
+
+		const openMenu = () => {
+			menu.classList.remove("hidden");
+			commentButton.classList.add("is-open");
+			commentButton.setAttribute("aria-expanded", "true");
+		};
 
 		if (canComment) {
-			const commentButton = box.querySelector(".compose-send-comment");
-
 			commentButton.onclick = () => {
 				const targets = replyTargets(stories);
 
@@ -15714,6 +15738,7 @@ ${settingsPanelHTML()}
 
 		if (canComment) {
 			holdComposeSendWidth(box.querySelector(".compose-send-comment"), [
+				"comment\u2026",
 				"posting…",
 				"posted",
 			]);
@@ -15744,10 +15769,9 @@ ${settingsPanelHTML()}
 		canComment
 			? `<button type="submit" class="composer-submit compose-send compose-send-comment" title="Add this as a comment"><span class="compose-send-label">comment</span></button>`
 			: ""
-	}</span>
+	}<div class="compose-targets hidden" role="menu"></div></span>
 	</div>
 	</div>
-	<div class="compose-targets hidden" role="menu"></div>
 	<div class="composer-help hidden">
 	<p>Blank lines separate paragraphs.</p>
 	<p>Text surrounded by asterisks is italicized. To get a literal asterisk, use <code>\\*</code> or <code>**</code>.</p>

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -2950,8 +2950,23 @@
 		return (disambiguating && story?.title) || page;
 	}
 
-	function stripCloseClearsFilter(opening, filter) {
-		return !opening && filter?.type === "discussion";
+	function sourceMenuGroups(stories, liveKeys) {
+		const live = new Set(liveKeys || []);
+		const busiest = (list) =>
+			[...list].sort((a, b) => (b.commentCount ?? 0) - (a.commentCount ?? 0));
+		const running = busiest((stories || []).filter((story) => live.has(story.key)));
+		const rest = busiest((stories || []).filter((story) => !live.has(story.key)));
+
+		if (!running.length) {
+			return rest.length ? [{ live: false, stories: rest }] : [];
+		}
+
+		return rest.length
+			? [
+					{ live: true, stories: running },
+					{ live: false, stories: rest },
+				]
+			: [{ live: true, stories: running }];
 	}
 
 	function newestCommentTime(comments, discussionKey) {
@@ -11656,24 +11671,101 @@ header button svg {
 	border-bottom:0;
 }
 
-.source-strip {
-	display:flex;
-	flex-wrap:wrap;
-	gap:6px;
-	overflow:hidden;
-	max-height:0;
-	opacity:0;
-	margin-top:0;
-	transition:max-height .22s ease, opacity .18s ease, margin-top .22s ease;
+.source-menu-anchor {
+	position:relative;
+	display:inline-flex;
 }
 
-.source-strip-single {
+.source-menu {
+	position:absolute;
+	left:0;
+	top:calc(100% + 4px);
+	z-index:4;
+	min-width:180px;
+	max-width:270px;
+	max-height:260px;
+	overflow-y:auto;
+	padding:8px;
+	border:1px solid var(--surface-border);
+	border-radius:8px;
+	background:var(--surface);
+	color:var(--surface-text);
+	box-shadow:0 8px 24px rgba(0,0,0,.16);
+	text-align:left;
+}
+
+.source-menu.hidden {
 	display:none;
 }
 
-.source-strip.is-open {
-	opacity:1;
+.source-menu-group + .source-menu-group {
 	margin-top:8px;
+	padding-top:8px;
+	border-top:1px solid var(--surface-divider);
+}
+
+.source-menu-head {
+	margin-bottom:6px;
+}
+
+.source-menu-head .live-pill {
+	margin-left:0;
+}
+
+.source-menu-option {
+	align-items:center;
+	padding:3px 4px;
+	border-radius:4px;
+	cursor:pointer;
+}
+
+.source-menu-option + .source-menu-option {
+	margin-top:2px;
+}
+
+.source-menu-option input[type="radio"] {
+	appearance:none;
+	-webkit-appearance:none;
+	box-sizing:border-box;
+	flex:0 0 auto;
+	width:13px;
+	height:13px;
+	margin:0;
+	border:1px solid var(--help-border);
+	border-radius:50%;
+	background:var(--help-bg);
+	cursor:pointer;
+	transition:border-color .14s ease, box-shadow .14s ease;
+}
+
+.source-menu-option input[type="radio"]:checked {
+	border-color:var(--accent);
+	box-shadow:inset 0 0 0 3px var(--surface);
+	background:var(--accent);
+}
+
+.source-menu-label {
+	min-width:0;
+	overflow:hidden;
+	text-overflow:ellipsis;
+	white-space:nowrap;
+}
+
+.source-menu-count {
+	margin-left:auto;
+	padding-left:8px;
+	color:var(--muted);
+	font-variant-numeric:tabular-nums;
+}
+
+.source-menu-option-active .source-menu-label {
+	font-weight:600;
+}
+
+@media (hover: hover) {
+	.source-menu-option:hover {
+		background:var(--hover-tint);
+	}
 }
 
 .page-header-disclosure,
@@ -11753,39 +11845,6 @@ header button svg {
 
 .list-filtered .page-sort {
 	display:none;
-}
-
-.source-strip-entry {
-	display:inline-flex;
-	align-items:baseline;
-	gap:5px;
-	padding:2px 7px;
-	border:0;
-	border-radius:999px;
-	background:var(--hover-tint);
-	color:inherit;
-	font:inherit;
-	font-size:11px;
-	cursor:pointer;
-}
-
-.source-strip-entry-active {
-	background:var(--active-tint);
-	font-weight:600;
-}
-
-.source-strip-label {
-	min-width:0;
-	max-width:16ch;
-	overflow:hidden;
-	text-overflow:ellipsis;
-	white-space:nowrap;
-}
-
-.source-strip-count {
-	flex:0 0 auto;
-	color:var(--muted);
-	font-variant-numeric:tabular-nums;
 }
 
 .more-replies {
@@ -17228,9 +17287,9 @@ ${settingsPanelHTML()}
 				}
 			}
 
-			for (const pill of body.querySelectorAll(".source-strip-entry")) {
-				if (pill.dataset.discussionKey === story.key) {
-					const shown = pill.querySelector(".source-strip-count");
+			for (const option of body.querySelectorAll(".source-menu-option")) {
+				if (option.dataset.discussionKey === story.key) {
+					const shown = option.querySelector(".source-menu-count");
 
 					if (shown) {
 						shown.textContent = String(count);
@@ -17504,7 +17563,7 @@ ${settingsPanelHTML()}
 <div class="page-header-title">${single ? "" : escapeHTML(page)}</div>
 <div class="page-header-meta">${
 	stories.length > 1
-		? `<span class="page-header-total">${escapeHTML(pluralize(total, "comment"))}</span> across <button type="button" class="page-header-disclosure" aria-expanded="false" aria-controls="source-strip">${escapeHTML(pluralize(stories.length, "discussion"))}</button><span class="page-header-sep">|</span>`
+		? `<span class="page-header-total">${escapeHTML(pluralize(total, "comment"))}</span> across <span class="source-menu-anchor"><button type="button" class="page-header-disclosure" aria-expanded="false" aria-haspopup="true" aria-controls="source-menu">${escapeHTML(pluralize(stories.length, "discussion"))}</button>${sourceMenuHTML(stories)}</span><span class="page-header-sep">|</span>`
 		: ""
 }${
 	stories.length > 1
@@ -17513,23 +17572,8 @@ ${settingsPanelHTML()}
 		}`
 		: ""
 }</div>
-<div class="source-strip${stories.length > 1 ? "" : " source-strip-single"}" id="source-strip">
-${
-	stories
-	.map(
-		(story, index) => `
-<button type="button" class="source-strip-entry"
-data-discussion-key="${escapeHTML(story.key)}"
-title="Show only this discussion">
-<span class="source-strip-label">${escapeHTML(liveDiscussions.has(story.key) ? story.baseLabel || story.label : story.label)}</span>
-<span class="source-strip-count">${escapeHTML(String(story.commentCount ?? 0))}</span>${liveDiscussions.has(story.key) ? `<span class="live-pill">LIVE</span>` : ""}
-</button>`,
-	)
-	.join("")
-}
-</div>`;
+`;
 
-		const strip = wrapper.querySelector(".source-strip");
 		wireWatchToggle(wrapper.querySelector(".page-header-watch"), page, stories);
 
 		const disclosure = wrapper.querySelector(".page-header-disclosure");
@@ -17541,47 +17585,48 @@ title="Show only this discussion">
 			return wrapper;
 		}
 
-		const setStripOpen = (open) => {
-			strip.classList.toggle("is-open", open);
+		const menu = wrapper.querySelector(".source-menu");
+
+		const setMenuOpen = (open) => {
+			menu.classList.toggle("hidden", !open);
 			disclosure.setAttribute("aria-expanded", open ? "true" : "false");
-
-			strip.style.maxHeight = open ? `${strip.scrollHeight}px` : "0px";
-
-			for (const entry of strip.querySelectorAll(".source-strip-entry")) {
-				entry.tabIndex = open ? 0 : -1;
-			}
 		};
 
-		setStripOpen(false);
+		setMenuOpen(false);
 
-		disclosure.onclick = () => {
-			const opening = !strip.classList.contains("is-open");
+		disclosure.onclick = () => setMenuOpen(menu.classList.contains("hidden"));
 
-			if (stripCloseClearsFilter(opening, activeCommentFilter)) {
-				clearCommentFilter({ restore: true });
-				syncFilterAffordances();
-			}
+		menu.addEventListener("click", (event) => {
+			const option = event.target.closest("input")?.closest(".source-menu-option");
 
-			setStripOpen(opening);
-		};
-
-		wrapper.querySelector(".source-strip").addEventListener("click", (event) => {
-			const entry = event.target.closest(".source-strip-entry");
-
-			if (!entry) {
+			if (!option) {
 				return;
 			}
 
-			const key = entry.dataset.discussionKey;
+			const key = option.dataset.discussionKey || "";
+			const already =
+				activeCommentFilter?.type === "discussion" && activeCommentFilter.key === key;
 
-			if (activeCommentFilter?.type === "discussion" && activeCommentFilter.key === key) {
+			if (!key || already) {
 				clearCommentFilter({ restore: true });
 			} else {
 				applyDiscussionFilter(key);
 			}
 
 			syncFilterAffordances();
-			setStripOpen(true);
+		});
+
+		menu.addEventListener("keydown", (event) => {
+			if (event.key === "Escape") {
+				setMenuOpen(false);
+				disclosure.focus();
+			}
+		});
+
+		wrapper.addEventListener("focusout", (event) => {
+			if (!wrapper.contains(event.relatedTarget)) {
+				setMenuOpen(false);
+			}
 		});
 
 		container.appendChild(wrapper);
@@ -17630,10 +17675,10 @@ title="Show only this discussion">
 	}
 
 	function syncFilterAffordances() {
-		const wrapper = sidebarUI?.body?.querySelector(".source-strip");
+		const menu = sidebarUI?.body?.querySelector(".source-menu");
 
-		if (wrapper) {
-			syncSourceStripState(wrapper);
+		if (menu) {
+			syncSourceMenuState(menu);
 		}
 
 		syncSubmissionDetails();
@@ -17650,15 +17695,57 @@ title="Show only this discussion">
 		sidebarUI?.body?.classList.toggle("list-filtered", Boolean(activeCommentFilter));
 	}
 
-	function syncSourceStripState(wrapper) {
+	let sourceMenuSeq = 0;
+
+	function sourceMenuHTML(stories) {
+		const name = `source-menu-${(sourceMenuSeq += 1)}`;
+		const groups = sourceMenuGroups(stories, liveDiscussions.keys());
+		const option = (key, label, count, live) => `
+<label class="settings-option source-menu-option"${key ? ` data-discussion-key="${escapeHTML(key)}"` : ""}>
+<input type="radio" name="${name}"${key ? "" : " checked"}>
+<span class="source-menu-label">${escapeHTML(label)}</span>${
+	count === null
+		? ""
+		: `<span class="source-menu-count">${escapeHTML(String(count))}</span>`
+}${live ? `<span class="live-pill">LIVE</span>` : ""}
+</label>`;
+
+		return `<div class="source-menu hidden" id="source-menu" role="menu">
+<div class="source-menu-group">${option("", "All sources", null, false)}</div>
+${groups
+	.map(
+		(group) => `<div class="source-menu-group">${
+			group.live && groups.length > 1
+				? `<div class="source-menu-head"><span class="live-pill">LIVE</span></div>`
+				: ""
+		}${group.stories
+			.map((story) =>
+				option(
+					story.key,
+					(liveDiscussions.has(story.key) ? story.baseLabel || story.label : story.label) || story.source,
+					story.commentCount ?? 0,
+					group.live && groups.length === 1,
+				),
+			)
+			.join("")}</div>`,
+	)
+	.join("")}
+</div>`;
+	}
+
+	function syncSourceMenuState(menu) {
 		const active =
 			activeCommentFilter?.type === "discussion" ? activeCommentFilter.key : null;
 
-		for (const entry of wrapper.querySelectorAll(".source-strip-entry")) {
-			entry.classList.toggle(
-				"source-strip-entry-active",
-				entry.dataset.discussionKey === active,
-			);
+		for (const option of menu.querySelectorAll(".source-menu-option")) {
+			const mine = (option.dataset.discussionKey || "") === (active || "");
+			const input = option.querySelector("input");
+
+			option.classList.toggle("source-menu-option-active", mine && Boolean(active));
+
+			if (input) {
+				input.checked = mine;
+			}
 		}
 	}
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -7665,7 +7665,7 @@ button {
 	function voteFailureMessage(result, sourceLabel = "the source") {
 		switch (result?.reason) {
 			case "popup-blocked":
-				return "Your browser blocked the popup. Allow popups for this site and try again.";
+				return "Your browser blocked the popup.";
 			case "timeout":
 				return `${sourceLabel} did not respond in time.`;
 			case "not-logged-in":
@@ -7739,19 +7739,26 @@ button {
 				return;
 			}
 
-			const button = document.createElement("button");
+			const control = document.createElement(action.href ? "a" : "button");
 
-			button.type = "button";
-			button.className = "vote-unvote-link";
-			button.textContent = action.label;
-			button.onclick = (event) => {
-				event.preventDefault();
-				event.stopPropagation();
-				action.onPress();
-			};
+			control.className = "vote-unvote-link";
+			control.textContent = action.label;
+
+			if (action.href) {
+				control.href = action.href;
+				control.target = "_blank";
+				control.rel = "noreferrer noopener";
+			} else {
+				control.type = "button";
+				control.onclick = (event) => {
+					event.preventDefault();
+					event.stopPropagation();
+					action.onPress();
+				};
+			}
 
 			element.appendChild(document.createTextNode(" "));
-			element.appendChild(button);
+			element.appendChild(control);
 		});
 	}
 
@@ -8130,20 +8137,21 @@ button {
 
 		setupItemActionListener();
 
-		return new Promise((resolve) => {
-			const nonce = bridgeNonce();
-			const popup = window.open(
-				itemActionPageURL(voteAction, {
-					storyID,
-					itemId,
-					action,
-					voteURL,
-					nonce,
-				}),
-				"hnewhere_vote_bridge_" + nonce,
-				"width=420,height=320,resizable=yes,scrollbars=yes",
-			);
+		const nonce = bridgeNonce();
+		const url = itemActionPageURL(voteAction, {
+			storyID,
+			itemId,
+			action,
+			voteURL,
+			nonce,
+		});
+		const popup = window.open(
+			url,
+			"hnewhere_vote_bridge_" + nonce,
+			"width=420,height=320,resizable=yes,scrollbars=yes",
+		);
 
+		return new Promise((resolve) => {
 			if (!popup) {
 				itemActionRequests.set(nonce, {
 					resolve: () => {},
@@ -8156,7 +8164,7 @@ button {
 					onInterim,
 					stopWatching: watchBridgeResult(nonce, deliverItemAction),
 				});
-				resolve({ ok: false, reason: "popup-blocked" });
+				resolve({ ok: false, reason: "popup-blocked", url });
 				return;
 			}
 
@@ -8176,7 +8184,7 @@ button {
 		});
 	}
 
-	async function submitVote(
+	function submitVote(
 		sourceID,
 		storyID,
 		itemId,
@@ -8185,10 +8193,10 @@ button {
 		{ force = false } = {},
 	) {
 		if (!container || container.dataset.votePending === "1") {
-			return;
+			return Promise.resolve();
 		}
 
-		if (!force && shouldAskToSignIn(await readAuthVerdict(sourceID), Date.now())) {
+		if (!force && shouldAskToSignIn(rememberedAuthVerdict(sourceID), Date.now())) {
 			showVoteMessage(
 				itemId,
 				`Sign in to ${getSource(sourceID)?.label || "the source"} to vote.`,
@@ -8200,7 +8208,7 @@ button {
 						}),
 				},
 			);
-			return;
+			return Promise.resolve();
 		}
 
 		container.dataset.votePending = "1";
@@ -8211,36 +8219,45 @@ button {
 
 		const label = getSource(sourceID)?.label || "the source";
 
-		try {
-			const result = await openItemActionPopup(
-				sourceID,
-				storyID,
-				itemId,
-				descriptor.action,
-				descriptor.url,
-				() => showToast(`Waiting for sign-in on ${label}…`, { persist: true }),
-			);
+		const opened = openItemActionPopup(
+			sourceID,
+			storyID,
+			itemId,
+			descriptor.action,
+			descriptor.url,
+			() => showToast(`Waiting for sign-in on ${label}…`, { persist: true }),
+		);
 
-			if (result?.storyID && result?.itemId && result?.voteInfo) {
-				setVoteInfoForStoryItem(result.storyID, result.itemId, result.voteInfo);
+		return (async () => {
+			try {
+				const result = await opened;
+
+				if (result?.storyID && result?.itemId && result?.voteInfo) {
+					setVoteInfoForStoryItem(result.storyID, result.itemId, result.voteInfo);
+				}
+
+				if (result?.ok) {
+					showToast(null);
+				} else if (result?.reason === "popup-blocked" && result.url) {
+					showVoteMessage(itemId, voteFailureMessage(result, label), {
+						label: `open ${label}`,
+						href: result.url,
+					});
+				} else if (isSidebarLevelReason(result?.reason)) {
+					showToast(voteFailureMessage(result, label));
+				} else {
+					showVoteMessage(itemId, voteFailureMessage(result, label));
+				}
+
+				await rememberAuthFromResult(sourceID, result);
+			} finally {
+				delete container.dataset.votePending;
+				container.classList.remove("vote-controls-pending");
+				container.querySelectorAll(".vote-button").forEach((button) => {
+					button.disabled = false;
+				});
 			}
-
-			if (result?.ok) {
-				showToast(null);
-			} else if (isSidebarLevelReason(result?.reason)) {
-				showToast(voteFailureMessage(result, label));
-			} else {
-				showVoteMessage(itemId, voteFailureMessage(result, label));
-			}
-
-			await rememberAuthFromResult(sourceID, result);
-		} finally {
-			delete container.dataset.votePending;
-			container.classList.remove("vote-controls-pending");
-			container.querySelectorAll(".vote-button").forEach((button) => {
-				button.disabled = false;
-			});
-		}
+		})();
 	}
 
 	// -------------------------
@@ -8290,15 +8307,38 @@ button {
 
 	// #endregion hnewhere-test-export
 
-	function readAuthVerdict(sourceID) {
-		return load(AUTH_PREFIX + sourceID, null);
+	const rememberedAuthVerdicts = new Map();
+
+	function rememberedAuthVerdict(sourceID) {
+		return rememberedAuthVerdicts.get(sourceID) || null;
+	}
+
+	async function readAuthVerdict(sourceID) {
+		const verdict = await load(AUTH_PREFIX + sourceID, null);
+
+		rememberedAuthVerdicts.set(sourceID, verdict);
+
+		return verdict;
+	}
+
+	function warmAuthVerdict(sourceID) {
+		if (!sourceID || rememberedAuthVerdicts.has(sourceID)) {
+			return;
+		}
+
+		rememberedAuthVerdicts.set(sourceID, null);
+		readAuthVerdict(sourceID).catch(() => {});
 	}
 
 	async function rememberAuthFromResult(sourceID, result) {
 		const state = verdictFromResult(result);
 
 		if (state) {
-			await save(AUTH_PREFIX + sourceID, { state, at: Date.now() });
+			const verdict = { state, at: Date.now() };
+
+			rememberedAuthVerdicts.set(sourceID, verdict);
+
+			await save(AUTH_PREFIX + sourceID, verdict);
 		}
 	}
 
@@ -8309,6 +8349,7 @@ button {
 
 		const sourceID = container.dataset.hnVoteSource;
 
+		warmAuthVerdict(sourceID);
 		container.replaceChildren();
 
 		const descriptors = voteDescriptorsFor(sourceID, voteInfo);
@@ -14095,6 +14136,7 @@ ${SUBMIT_FORM_CSS}
 	margin:0;
 	color:inherit;
 	font:inherit;
+	text-decoration:none;
 	cursor:pointer;
 }
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -10849,7 +10849,7 @@ header {
 
 .browse-view {
 	display:none;
-	--browse-indent:28px;
+	--browse-indent:23px;
 }
 
 #comments-content,
@@ -10864,6 +10864,7 @@ header {
 }
 
 #browse-list {
+	padding-left:8px;
 	transition:opacity .16s ease, transform .16s ease;
 }
 
@@ -10913,7 +10914,6 @@ header {
 
 .browse-subhead {
 	margin:0 0 6px;
-	padding-left:8px;
 	color:var(--meta);
 	font-size:11px;
 	font-family:Verdana, Geneva, sans-serif;
@@ -11067,7 +11067,7 @@ header {
 }
 
 .browse-skeleton {
-	margin-left:8px;
+	margin-left:0;
 }
 
 .browse-skeleton-label {
@@ -11165,14 +11165,14 @@ header {
 
 .browse-rank {
 	flex:0 0 auto;
-	min-width:22px;
-	text-align:right;
+	min-width:17px;
+	text-align:left;
 	color:var(--meta);
 	font-size:11px;
 }
 
 .browse-row-loose {
-	padding:0 0 0 8px;
+	padding:0;
 }
 
 .browse-row-loose + .browse-row-loose {
@@ -11605,7 +11605,8 @@ header button svg {
 }
 
 .page-header {
-	padding:0 14px 10px;
+	margin-left:8px;
+	padding:0 14px 10px 0;
 	border-bottom:1px solid var(--border-soft);
 }
 
@@ -11678,7 +11679,7 @@ header button svg {
 	display:flex;
 	align-items:center;
 	gap:6px;
-	padding:8px 0 0;
+	padding:8px 0 0 8px;
 	font-size:11px;
 	color:var(--meta);
 }
@@ -11812,7 +11813,7 @@ header button svg {
 	align-items:center;
 	gap:6px;
 	margin:0 -12px;
-	padding:10px 12px 0;
+	padding:10px 12px 0 20px;
 	font-size:11px;
 	color:var(--meta);
 	line-height:13px;
@@ -13789,7 +13790,7 @@ ${SUBMIT_FORM_CSS}
 	align-items:center;
 	gap:6px;
 	margin:0 -12px;
-	padding:10px 12px 0;
+	padding:10px 12px 0 20px;
 	font-size:11px;
 	color:var(--meta);
 	line-height:13px;
@@ -14524,6 +14525,10 @@ blockquote.comment-quote-redundant {
 
 .story-text a {
 	color:var(--link);
+}
+
+.story-body-cell > .comment-composer {
+	margin-left:calc(8px - var(--vote-column));
 }
 
 .comment-composer {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -4629,19 +4629,18 @@ button {
 	}
 
 	function placeNotesSection(ui, section) {
-		const storyCell = ui.body?.querySelector(".submission-detail .story-body-cell");
+		const box =
+			ui.body.querySelector(".compose-box") ||
+			ui.body.querySelector(".compose-spacer");
 
-		if (storyCell && !storyCell.closest("[hidden]")) {
-			section.classList.add("notepad-section-inline");
-			storyCell.insertBefore(section, storyCell.querySelector(".compose-box"));
+		if (box) {
+			box.after(section);
 			return;
 		}
 
-		section.classList.remove("notepad-section-inline");
 		ui.body.insertBefore(
 			section,
-			ui.body.querySelector(".compose-box") ||
-				ui.body.querySelector(".page-sort") ||
+			ui.body.querySelector(".page-sort") ||
 				ui.body.querySelector(".top-level-comments"),
 		);
 	}
@@ -13839,26 +13838,6 @@ ${SUBMIT_FORM_CSS}
 	background:var(--surface-border);
 }
 
-.notepad-section-inline {
-	margin-top:14px;
-}
-
-.notepad-section-inline::before {
-	content:"";
-	display:block;
-	height:1px;
-	margin:0 0 0 calc(8px - var(--vote-column));
-	background:var(--surface-border);
-}
-
-.notepad-section-inline .notepad-rule {
-	margin-left:calc(-12px - var(--vote-column));
-}
-
-.notepad-section-inline .notepad-body {
-	margin-left:calc(8px - var(--vote-column));
-}
-
 .notepad-rule-close {
 	padding-top:8px;
 }
@@ -14575,7 +14554,7 @@ blockquote.comment-quote-redundant {
 
 .compose-box {
 	position:relative;
-	margin:0 0 14px 8px;
+	margin:14px 0 14px 8px;
 }
 
 .compose-anchor {
@@ -14617,17 +14596,23 @@ blockquote.comment-quote-redundant {
 	transition:max-height .22s ease;
 }
 
+.compose-dock.is-docked {
+	border-radius:6px;
+	box-shadow:0 6px 18px rgba(0,0,0,.22);
+}
+
 .compose-dock.is-docked .compose-dock-pill {
-	margin-bottom:6px;
-	border-radius:6px 6px 0 0;
 	width:100%;
+	padding:7px 12px;
+	border-radius:6px 6px 0 0;
+	box-shadow:none;
+	text-align:left;
 }
 
 .compose-dock.is-docked .compose-dock-slot {
-	padding:0 0 8px;
+	padding:8px 0;
 	border-radius:0 0 6px 6px;
 	background:var(--surface);
-	box-shadow:0 6px 18px rgba(0,0,0,.22);
 }
 
 .compose-dock .compose-box {
@@ -15478,8 +15463,14 @@ ${settingsPanelHTML()}
 		);
 	}
 
+	function composeDockLabel(canComment) {
+		return canComment ? "Add a comment" : "Keep a note";
+	}
+
 	function syncComposeBox() {
-		const box = sidebarUI?.body?.querySelector(".compose-box");
+		const box =
+			sidebarUI?.body?.querySelector(".compose-box") ||
+			sidebarUI?.shadow?.querySelector("#compose-dock-slot .compose-box");
 		const button = box?.querySelector(".compose-send-comment");
 
 		if (!box || !button) {
@@ -15488,8 +15479,13 @@ ${settingsPanelHTML()}
 
 		const targets = replyTargets();
 		const canNote = Boolean(box.querySelector(".compose-send-note"));
+		const pill = sidebarUI.shadow.querySelector("#compose-dock-pill");
 
 		button.hidden = targets.length === 0;
+
+		if (pill) {
+			pill.textContent = composeDockLabel(targets.length > 0);
+		}
 
 		if (!targets.length) {
 			box.querySelector(".compose-targets")?.classList.add("hidden");
@@ -15661,11 +15657,7 @@ ${settingsPanelHTML()}
 
 		syncComposeBox();
 
-		box._hnewhereDock = wireComposeDock(
-			ui,
-			box,
-			canComment ? "Add a comment" : "Keep a note",
-		);
+		box._hnewhereDock = wireComposeDock(ui, box, composeDockLabel(canComment));
 
 		return box;
 	}

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -362,6 +362,7 @@
 		buttonMark: BUTTON_MARK_DEFAULT,
 		accentColor: null,
 		commentSort: "best",
+		newCommentsFirst: false,
 	};
 
 	// #region hnewhere-test-export
@@ -462,6 +463,20 @@
 	async function getSeenTime(storyID) {
 		const seen = await load(STORAGE.seen, {});
 		return seen[storyID] || 0;
+	}
+
+	const visitSeenTimes = new Map();
+
+	async function visitSeenTime(storyID) {
+		if (!visitSeenTimes.has(storyID)) {
+			visitSeenTimes.set(storyID, await getSeenTime(storyID));
+		}
+
+		return visitSeenTimes.get(storyID);
+	}
+
+	function forgetVisitSeenTimes() {
+		visitSeenTimes.clear();
 	}
 
 	async function markSeen(storyID) {
@@ -2562,28 +2577,40 @@
 			const live = Boolean(group.story) && isDiscussionLive(group.thread, now);
 
 			group.rootKeys.forEach((key, index) => {
+				const createdAt = group.thread?.rootTimes?.get(key) || 0;
+
 				entries.push({
 					key,
 					discussionKey: group.discussionKey,
 					position: blendPosition(index, total) / weight,
-					createdAt: group.thread?.rootTimes?.get(key) || 0,
+					createdAt,
+					unread: isNewComment({ createdAt }, group.seenTime || 0),
 					live,
 					size: total,
 				});
 			});
 		}
 
+		const unreadFirst = options.unreadFirst
+			? (a, b) => Number(b.unread) - Number(a.unread)
+			: () => 0;
+
 		if (options.sort === "newest") {
-			return entries.sort((a, b) => b.createdAt - a.createdAt || b.size - a.size);
+			return entries.sort(
+				(a, b) => unreadFirst(a, b) || b.createdAt - a.createdAt || b.size - a.size,
+			);
 		}
 
 		if (options.sort === "oldest") {
-			return entries.sort((a, b) => a.createdAt - b.createdAt || b.size - a.size);
+			return entries.sort(
+				(a, b) => unreadFirst(a, b) || a.createdAt - b.createdAt || b.size - a.size,
+			);
 		}
 
 		return entries.sort(
 			(a, b) =>
 				Number(b.live) - Number(a.live) ||
+				unreadFirst(a, b) ||
 				a.position - b.position ||
 				b.size - a.size,
 		);
@@ -4748,6 +4775,24 @@ button {
 		await refreshArticleAnnotations();
 	}
 
+	function syncNewCommentsFirstControl(ui, entries, settings) {
+		const control = ui?.shadow?.querySelector("#sort-new-first");
+
+		if (!control) {
+			return;
+		}
+
+		const unread = entries.some((entry) => entry.unread);
+		const row = control.closest(".page-sort");
+
+		control.hidden = !unread;
+		control.classList.toggle("is-on", Boolean(settings.newCommentsFirst));
+
+		if (row?.classList.contains("page-sort-bare")) {
+			row.hidden = !unread;
+		}
+	}
+
 	function removeNoteAffordance() {
 		document.querySelector("[data-hnewhere-note-add]")?.remove();
 	}
@@ -6136,9 +6181,15 @@ button {
 		return pluralize(days, "day") + " ago";
 	}
 
+	// #region hnewhere-test-export
 	function isNewComment(comment, seenTimestamp) {
-		return comment.createdAt && comment.createdAt > seenTimestamp;
+		if (!seenTimestamp) {
+			return false;
+		}
+
+		return Boolean(comment.createdAt) && comment.createdAt > seenTimestamp;
 	}
+	// #endregion hnewhere-test-export
 
 	const PORTRAIT_SIDEBAR_GUTTER = 28;
 
@@ -11504,6 +11555,33 @@ header button svg {
 	cursor:pointer;
 }
 
+.page-sort-toggle {
+	border:0;
+	padding:0;
+	background:none;
+	color:var(--meta);
+	cursor:pointer;
+	font:inherit;
+	text-decoration:underline dotted;
+	text-underline-offset:2px;
+}
+
+.page-sort-toggle[hidden],
+.page-sort[hidden] {
+	display:none;
+}
+
+.page-sort-toggle.is-on {
+	color:var(--text);
+	text-decoration:underline;
+}
+
+@media (hover: hover) {
+	.page-sort-toggle:not(.is-on):hover {
+		text-decoration:underline;
+	}
+}
+
 .list-filtered .page-sort {
 	display:none;
 }
@@ -15208,10 +15286,15 @@ ${settingsPanelHTML()}
 		}
 
 		element.classList.add("comment-new-seen");
+		cancelNewCommentDwell(element);
 		newCommentScrollObserver?.unobserve(element);
 	}
 
 	let newCommentScrollObserver = null;
+
+	const newCommentDwells = new Map();
+
+	const NEW_COMMENT_DWELL_MS = 900;
 
 	let suppressNewCommentAutoClearUntil = 0;
 
@@ -15219,16 +15302,33 @@ ${settingsPanelHTML()}
 		suppressNewCommentAutoClearUntil = Date.now() + duration;
 	}
 
-	function newCommentAutoClearEnabled() {
-		if (typeof window.matchMedia !== "function") {
-			return false;
+	function cancelNewCommentDwell(element) {
+		clearTimeout(newCommentDwells.get(element));
+		newCommentDwells.delete(element);
+	}
+
+	function startNewCommentDwell(element) {
+		if (newCommentDwells.has(element)) {
+			return;
 		}
 
-		return !window.matchMedia("(hover: hover)").matches;
+		newCommentDwells.set(
+			element,
+			window.setTimeout(() => {
+				newCommentDwells.delete(element);
+
+				if (Date.now() < suppressNewCommentAutoClearUntil) {
+					startNewCommentDwell(element);
+					return;
+				}
+
+				startNewCommentFade(element);
+			}, NEW_COMMENT_DWELL_MS),
+		);
 	}
 
 	function observeNewCommentForScroll(element) {
-		if (!newCommentAutoClearEnabled() || typeof IntersectionObserver !== "function") {
+		if (typeof IntersectionObserver !== "function") {
 			return;
 		}
 
@@ -15241,21 +15341,11 @@ ${settingsPanelHTML()}
 
 			newCommentScrollObserver = new IntersectionObserver(
 				(entries) => {
-					if (Date.now() < suppressNewCommentAutoClearUntil) {
-						return;
-					}
-
 					for (const entry of entries) {
-						if (entry.isIntersecting || !entry.rootBounds) {
-							continue;
-						}
-
-						if (!entry.boundingClientRect.height) {
-							continue;
-						}
-
-						if (entry.boundingClientRect.bottom <= entry.rootBounds.top) {
-							startNewCommentFade(entry.target);
+						if (entry.isIntersecting) {
+							startNewCommentDwell(entry.target);
+						} else {
+							cancelNewCommentDwell(entry.target);
 						}
 					}
 				},
@@ -15267,6 +15357,10 @@ ${settingsPanelHTML()}
 	}
 
 	function stopObservingNewComments() {
+		for (const element of [...newCommentDwells.keys()]) {
+			cancelNewCommentDwell(element);
+		}
+
 		newCommentScrollObserver?.disconnect();
 		newCommentScrollObserver = null;
 	}
@@ -16056,10 +16150,16 @@ ${settingsPanelHTML()}
 		comments.className = "top-level-comments";
 		ui.body.appendChild(comments);
 
+		const sortRow = ui.body.querySelector(".page-sort");
+
+		if (sortRow) {
+			ui.body.insertBefore(sortRow, comments);
+		}
+
 		const collapsedKeys = await loadCollapsed();
 		const seenTimes = new Map(
 			await Promise.all(
-				stories.map(async (story) => [story.key, await getSeenTime(story.key)]),
+				stories.map(async (story) => [story.key, await visitSeenTime(story.key)]),
 			),
 		);
 
@@ -16113,12 +16213,16 @@ ${settingsPanelHTML()}
 				rootKeys: threads[index].rootKeys,
 				story,
 				thread: threads[index],
+				seenTime: seenTimes.get(story.key) || 0,
 			})),
 			{
 				sort: settings.commentSort,
 				arrivedFrom: arrivalSource(),
+				unreadFirst: Boolean(settings.newCommentsFirst),
 			},
 		);
+
+		syncNewCommentsFirstControl(ui, entries, settings);
 
 		const liveRunEnd =
 			(settings.commentSort || "best") === "best"
@@ -16473,6 +16577,56 @@ ${settingsPanelHTML()}
 		liveBookendObservers.set(names, observer);
 	}
 
+	function mountSortRow(container, sort, options, withSort) {
+		const sortRow = document.createElement("div");
+
+		sortRow.className = withSort ? "page-sort" : "page-sort page-sort-bare";
+		sortRow.innerHTML = `${
+			withSort
+				? `<label class="page-sort-label" for="comment-sort">Sort</label>
+<select class="page-sort-select" id="comment-sort">${SORT_MODES.map(
+						(mode) =>
+							`<option value="${mode.id}"${mode.id === sort ? " selected" : ""}>${mode.label}</option>`,
+					).join("")}</select>
+`
+				: ""
+		}<button id="sort-new-first" class="page-sort-toggle" type="button" hidden>prioritize unread</button>`;
+
+		sortRow.querySelector("#sort-new-first").onclick = async (event) => {
+			const control = event.currentTarget;
+			const next = !(await loadSettings()).newCommentsFirst;
+
+			await saveSettings({ newCommentsFirst: next });
+			control.classList.toggle("is-on", next);
+
+			if (typeof options.onSortChange === "function") {
+				await options.onSortChange(sort);
+			}
+		};
+
+		if (withSort) {
+			sortRow.querySelector(".page-sort-select").onchange = async (event) => {
+				const next = event.target.value;
+
+				if (next === sort) {
+					return;
+				}
+
+				await saveSettings({ commentSort: next });
+
+				if (typeof options.onSortChange === "function") {
+					await options.onSortChange(next);
+				}
+			};
+		}
+
+		if (!withSort) {
+			sortRow.hidden = true;
+		}
+
+		container.appendChild(sortRow);
+	}
+
 	function renderPageHeader(stories, container, options = {}) {
 		const sort = options.sort || "best";
 		const page = options.page ?? discussionsPageTitle(stories);
@@ -16532,6 +16686,7 @@ title="Show only this discussion">
 
 		if (!disclosure) {
 			container.appendChild(wrapper);
+			mountSortRow(container, sort, options, false);
 
 			return wrapper;
 		}
@@ -16581,31 +16736,7 @@ title="Show only this discussion">
 
 		container.appendChild(wrapper);
 
-		const sortRow = document.createElement("div");
-
-		sortRow.className = "page-sort";
-		sortRow.innerHTML = `
-<label class="page-sort-label" for="comment-sort">Sort</label>
-<select class="page-sort-select" id="comment-sort">${SORT_MODES.map(
-			(mode) =>
-				`<option value="${mode.id}"${mode.id === sort ? " selected" : ""}>${mode.label}</option>`,
-		).join("")}</select>`;
-
-		sortRow.querySelector(".page-sort-select").onchange = async (event) => {
-			const next = event.target.value;
-
-			if (next === sort) {
-				return;
-			}
-
-			await saveSettings({ commentSort: next });
-
-			if (typeof options.onSortChange === "function") {
-				await options.onSortChange(next);
-			}
-		};
-
-		container.appendChild(sortRow);
+		mountSortRow(container, sort, options, true);
 
 		return wrapper;
 	}
@@ -21414,6 +21545,7 @@ title="Show only this discussion">
 		teardownSurfaces();
 
 		stopObservingNewComments();
+		forgetVisitSeenTimes();
 		renderedComments = [];
 		activeCommentFilter = null;
 	}

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -21114,9 +21114,70 @@ title="Show only this discussion">
 			});
 		};
 
+		const observedSizes = new WeakMap();
+
+		const geometryMoved = (entries) => {
+			let moved = false;
+
+			for (const entry of entries) {
+				const box = entry.contentRect;
+				const seen = observedSizes.get(entry.target);
+
+				if (
+					seen &&
+					Math.abs(seen.width - box.width) < 1 &&
+					Math.abs(seen.height - box.height) < 1
+				) {
+					continue;
+				}
+
+				observedSizes.set(entry.target, { width: box.width, height: box.height });
+				moved = true;
+			}
+
+			return moved;
+		};
+
+		const geometryObserver =
+			typeof ResizeObserver === "function"
+				? new ResizeObserver((entries) => {
+						if (geometryMoved(entries)) {
+							scheduleRender();
+						}
+					})
+				: null;
+
+		const watchGeometry = () => {
+			if (!geometryObserver) {
+				return;
+			}
+
+			const already = new Set();
+			const containers = groups.map((group) =>
+				nearestElement(group.range?.commonAncestorContainer),
+			);
+
+			for (const element of [overlayHost, ...containers]) {
+				if (!element || already.has(element) || overlay.contains(element)) {
+					continue;
+				}
+
+				already.add(element);
+
+				const box = element.getBoundingClientRect();
+
+				observedSizes.set(element, { width: box.width, height: box.height });
+				geometryObserver.observe(element);
+			}
+		};
+
+		const onFontsSettled = () => scheduleRender();
+
 		window.addEventListener("resize", scheduleRender);
 		window.addEventListener("load", scheduleRender, true);
+		document.fonts?.addEventListener?.("loadingdone", onFontsSettled);
 		render();
+		watchGeometry();
 
 		return {
 			groups,
@@ -21137,6 +21198,8 @@ title="Show only this discussion">
 			cleanup() {
 				window.removeEventListener("resize", scheduleRender);
 				window.removeEventListener("load", scheduleRender, true);
+				document.fonts?.removeEventListener?.("loadingdone", onFontsSettled);
+				geometryObserver?.disconnect();
 
 				if (renderFrame) {
 					cancelAnimationFrame(renderFrame);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -9365,10 +9365,10 @@ button {
 		};
 
 		if (saved.length) {
-			subhead(list, "favorite discussions");
+			const section = subhead(list, "favorite discussions", { collapsible: true });
 
 			for (const entry of saved) {
-				collectionRow(entry, list, null, {
+				collectionRow(entry, section, null, {
 					unfavorite: entry.key,
 					reload,
 				});
@@ -9376,10 +9376,10 @@ button {
 		}
 
 		if (comments.length) {
-			subhead(list, "favorite comments");
+			const section = subhead(list, "favorite comments", { collapsible: true });
 
 			for (const entry of comments) {
-				const row = collectionRow(entry, list, null, {
+				const row = collectionRow(entry, section, null, {
 					unfavorite: entry.key,
 					reload,
 				});
@@ -9399,10 +9399,10 @@ button {
 		}
 
 		if (noted.length) {
-			subhead(list, "notes");
+			const section = subhead(list, "notes", { collapsible: true });
 
 			for (const entry of noted) {
-				noteCollectionRow(entry, list, {
+				noteCollectionRow(entry, section, {
 					onDelete: async (page, note) => {
 						await deleteCollectedNote(page, note);
 						await reload();
@@ -9738,12 +9738,42 @@ button {
 		return updates.size > 0;
 	}
 
-	function subhead(list, text) {
+	function subhead(list, text, { collapsible = false } = {}) {
 		const heading = document.createElement("div");
 
 		heading.className = "browse-subhead";
 		heading.textContent = text;
-		list.appendChild(heading);
+
+		if (!collapsible) {
+			list.appendChild(heading);
+			return list;
+		}
+
+		const section = document.createElement("div");
+		const body = document.createElement("div");
+		const toggle = document.createElement("button");
+
+		section.className = "browse-section";
+		body.className = "browse-section-body";
+
+		toggle.type = "button";
+		toggle.className = "browse-subhead-toggle";
+
+		const paint = (collapsed) => {
+			toggle.textContent = collapsed ? "[+]" : "[–]";
+			toggle.setAttribute("aria-expanded", String(!collapsed));
+			toggle.setAttribute("aria-label", (collapsed ? "Expand " : "Collapse ") + text);
+		};
+
+		paint(false);
+
+		toggle.onclick = () => paint(section.classList.toggle("is-collapsed"));
+
+		heading.appendChild(toggle);
+		section.append(heading, body);
+		list.appendChild(section);
+
+		return body;
 	}
 
 	async function renderQueueView(ui, list) {
@@ -10926,10 +10956,29 @@ header {
 	font-family:Verdana, Geneva, sans-serif;
 }
 
-.browse-row + .browse-subhead {
+.browse-row + .browse-subhead,
+.browse-section + .browse-section > .browse-subhead {
 	margin-top:14px;
 	padding-top:14px;
 	border-top:1px solid var(--surface-divider);
+}
+
+.browse-subhead-toggle {
+	margin-left:6px;
+	border:0;
+	padding:0;
+	background:none;
+	color:var(--meta);
+	font:inherit;
+	cursor:pointer;
+}
+
+.browse-section.is-collapsed > .browse-subhead {
+	margin-bottom:0;
+}
+
+.browse-section.is-collapsed > .browse-section-body {
+	display:none;
 }
 
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Backchannel
 // @namespace    https://github.com/twalichiewicz/HNewhere
-// @version      1.6.10
+// @version      1.6.11
 // @license      MIT
 // @updateURL    https://raw.githubusercontent.com/twalichiewicz/Backchannel/main/HNewhere.user.js
 // @downloadURL  https://raw.githubusercontent.com/twalichiewicz/Backchannel/main/HNewhere.user.js

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -12675,6 +12675,11 @@ ${subtitle ? `<span id="header-subtitle" class="header-subtitle"></span>` : ""}
 <path d="M4.5 7.7 8 4.2l3.5 3.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>
 </button>
+<button id="comment-toggle" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="compose-dock" aria-label="Add a comment" title="Add a comment" hidden>
+<svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true" focusable="false">
+<path fill="currentColor" fill-rule="evenodd" d="M3.7 2.5h8.6A1.5 1.5 0 0 1 13.8 4v5.5A1.5 1.5 0 0 1 12.3 11H7.6l-2.5 2.4V11H3.7A1.5 1.5 0 0 1 2.2 9.5V4A1.5 1.5 0 0 1 3.7 2.5ZM5.3 5.8a.95.95 0 1 0 0 1.9.95.95 0 0 0 0-1.9Zm2.7 0a.95.95 0 1 0 0 1.9.95.95 0 0 0 0-1.9Zm2.7 0a.95.95 0 1 0 0 1.9.95.95 0 0 0 0-1.9Z"/>
+</svg>
+</button>
 <span class="hide-control">
 <button id="hide-site" class="has-scope" aria-haspopup="true" aria-expanded="false" aria-label="Hide Backchannel here" title="Hide Backchannel here">
 <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true" focusable="false">
@@ -14668,17 +14673,17 @@ blockquote.comment-quote-redundant {
 	margin:15px 0 15px 8px;
 }
 
-.compose-anchor {
-	height:0;
-}
-
 .compose-dock {
 	position:absolute;
 	top:8px;
-	left:50%;
-	transform:translateX(-50%);
-	width:calc(100% - 24px);
-	max-width:calc(100% - 24px);
+	left:8px;
+	right:8px;
+	z-index:5;
+	padding:8px;
+	border:1px solid var(--surface-border);
+	border-radius:8px;
+	background:var(--surface);
+	box-shadow:0 8px 24px rgba(0,0,0,.18);
 	pointer-events:auto;
 }
 
@@ -14686,54 +14691,12 @@ blockquote.comment-quote-redundant {
 	display:none;
 }
 
-.compose-dock-pill {
-	display:block;
-	margin:0 auto;
-	padding:6px 14px;
-	border:0;
-	border-radius:999px;
-	background:var(--accent);
-	color:var(--accent-ink);
-	box-shadow:0 4px 14px rgba(0,0,0,.22);
-	font:inherit;
-	font-size:12px;
-	line-height:1.4;
-	cursor:pointer;
-}
-
-.compose-dock-slot {
-	overflow:hidden;
-	max-height:0;
-	transition:max-height .22s ease;
-}
-
-.compose-dock.is-docked {
-	border-radius:6px;
-	box-shadow:0 6px 18px rgba(0,0,0,.22);
-}
-
-.compose-dock.is-docked .compose-dock-pill {
-	width:100%;
-	padding:7px 12px;
-	border-radius:6px 6px 0 0;
-	box-shadow:none;
-	text-align:left;
-}
-
-.compose-dock.is-docked .compose-dock-slot {
-	padding:8px 0;
-	border-radius:0 0 6px 6px;
-	background:var(--surface);
-}
-
 .compose-dock .compose-box {
-	margin:0 8px;
+	margin:0;
 }
 
-@media (prefers-reduced-motion: reduce) {
-	.compose-dock-slot {
-		transition:none;
-	}
+#comment-toggle.is-open {
+	background:var(--active-tint);
 }
 
 .compose-field {
@@ -15084,7 +15047,7 @@ blockquote.comment-quote-redundant {
 <div id="resize-handle" aria-hidden="true"></div>
 
 ${headerHTML({ subtitle: true, minimize: true, browse: true })}
-<div class="toast-layer"><div id="toast" class="toast" role="status" aria-live="polite"></div><div id="compose-dock" class="compose-dock" hidden><button type="button" id="compose-dock-pill" class="compose-dock-pill"></button><div id="compose-dock-slot" class="compose-dock-slot"></div></div></div>
+<div class="toast-layer"><div id="toast" class="toast" role="status" aria-live="polite"></div><div id="compose-dock" class="compose-dock" hidden><div id="compose-dock-slot" class="compose-dock-slot"></div></div></div>
 ${settingsPanelHTML()}
 <div id="comments">
 <div id="filter-banner" class="filter-banner hidden">
@@ -15535,23 +15498,19 @@ ${settingsPanelHTML()}
 
 	function wireComposeDock(ui, box, label) {
 		const dock = ui.shadow.querySelector("#compose-dock");
-		const pill = ui.shadow.querySelector("#compose-dock-pill");
 		const slot = ui.shadow.querySelector("#compose-dock-slot");
-		const root = ui.body?.closest("#comments");
+		const control = ui.shadow.querySelector("#comment-toggle");
 
-		if (!dock || !pill || !slot || !root || typeof IntersectionObserver !== "function") {
+		if (!dock || !slot || !control) {
 			return null;
 		}
-
-		const anchorNode = document.createElement("div");
-
-		anchorNode.className = "compose-anchor";
-		box.parentElement.insertBefore(anchorNode, box);
 
 		const spacer = document.createElement("div");
 
 		spacer.className = "compose-spacer";
-		pill.textContent = label;
+		control.hidden = false;
+		control.title = label;
+		control.setAttribute("aria-label", label);
 
 		let docked = false;
 
@@ -15561,10 +15520,10 @@ ${settingsPanelHTML()}
 			}
 
 			docked = false;
-			dock.classList.remove("is-open");
-			slot.style.maxHeight = "0px";
+			dock.hidden = true;
+			control.classList.remove("is-open");
+			control.setAttribute("aria-expanded", "false");
 			spacer.replaceWith(box);
-			dock.classList.remove("is-docked");
 		};
 
 		const dockBox = () => {
@@ -15576,41 +15535,26 @@ ${settingsPanelHTML()}
 			spacer.style.height = `${box.getBoundingClientRect().height}px`;
 			box.replaceWith(spacer);
 			slot.appendChild(box);
-			dock.classList.add("is-docked");
-
-			requestAnimationFrame(() => {
-				dock.classList.add("is-open");
-				slot.style.maxHeight = `${slot.scrollHeight}px`;
-				box.querySelector(".composer-text")?.focus({ preventScroll: true });
-			});
+			dock.hidden = false;
+			control.classList.add("is-open");
+			control.setAttribute("aria-expanded", "true");
+			box.querySelector(".composer-text")?.focus({ preventScroll: true });
 		};
 
-		pill.onclick = () => (docked ? undock() : dockBox());
+		control.onclick = (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+			return docked ? undock() : dockBox();
+		};
 
 		dock.addEventListener("keydown", (event) => {
 			if (event.key === "Escape") {
 				undock();
+				control.focus();
 			}
 		});
 
-		const observer = new IntersectionObserver(
-			(entries) => {
-				for (const entry of entries) {
-					const gone = !entry.isIntersecting && entry.boundingClientRect.top < (entry.rootBounds?.top ?? 0);
-
-					dock.hidden = !gone;
-
-					if (!gone) {
-						undock();
-					}
-				}
-			},
-			{ root, threshold: 0 },
-		);
-
-		observer.observe(anchorNode);
-
-		return { undock, stop: () => observer.disconnect() };
+		return { undock, stop: () => undock() };
 	}
 
 	function replyTargets(stories = renderedDiscussions || []) {
@@ -15707,7 +15651,7 @@ ${settingsPanelHTML()}
 
 		const targets = replyTargets();
 		const canNote = Boolean(box.querySelector(".compose-send-note"));
-		const pill = sidebarUI.shadow.querySelector("#compose-dock-pill");
+		const control = sidebarUI.shadow.querySelector("#comment-toggle");
 		const word = targets.length > 1 ? "comment\u2026" : "comment";
 
 		button.hidden = targets.length === 0;
@@ -15717,8 +15661,11 @@ ${settingsPanelHTML()}
 			composeSendLabel(button).textContent = word;
 		}
 
-		if (pill) {
-			pill.textContent = composeDockLabel(targets.length > 0);
+		if (control) {
+			const label = composeDockLabel(targets.length > 0);
+
+			control.title = label;
+			control.setAttribute("aria-label", label);
 		}
 
 		if (!targets.length) {
@@ -15739,6 +15686,12 @@ ${settingsPanelHTML()}
 		);
 
 		if (!canComment && !canNote) {
+			const control = ui.shadow.querySelector("#comment-toggle");
+
+			if (control) {
+				control.hidden = true;
+			}
+
 			return null;
 		}
 

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -20498,6 +20498,97 @@ title="Show only this discussion">
 		return node;
 	}
 
+	const PRESSABLE_SELECTOR = `a[href],button,input,select,textarea,summary,[role="button"],[role="link"],[contenteditable=""],[contenteditable="true"]`;
+
+	const MIN_HIT_WIDTH = 8;
+
+	function shareALine(rect, other) {
+		const overlap =
+			Math.min(rect.top + rect.height, other.top + other.height) -
+			Math.max(rect.top, other.top);
+
+		return overlap > Math.min(rect.height, other.height) / 2;
+	}
+
+	function subtractSpans(rect, blockers) {
+		let pieces = [rect];
+
+		for (const blocker of blockers) {
+			const next = [];
+
+			for (const piece of pieces) {
+				const right = piece.left + piece.width;
+				const blockerRight = blocker.left + blocker.width;
+
+				if (
+					!shareALine(piece, blocker) ||
+					blockerRight <= piece.left ||
+					blocker.left >= right
+				) {
+					next.push(piece);
+					continue;
+				}
+
+				if (blocker.left > piece.left) {
+					next.push({ ...piece, width: blocker.left - piece.left });
+				}
+
+				if (blockerRight < right) {
+					next.push({ ...piece, left: blockerRight, width: right - blockerRight });
+				}
+			}
+
+			pieces = next;
+		}
+
+		return pieces.filter((piece) => piece.width >= MIN_HIT_WIDTH);
+	}
+
+	function coversWholeRect(pieces, rect) {
+		return (
+			pieces.length === 1 &&
+			Math.round(pieces[0].left) === Math.round(rect.left) &&
+			Math.round(pieces[0].width) === Math.round(rect.width)
+		);
+	}
+
+	const OWN_SURFACE_SELECTOR = `[data-hnewhere-annotation-overlay],[data-hnewhere-sidebar],[data-hnewhere-note-composer],[data-hnewhere-note-add],[data-hnewhere-submit-popover]`;
+
+	function pressableRectsAround(range, source = documentSource()) {
+		const root = nearestElement(range?.commonAncestorContainer);
+
+		if (!root?.querySelectorAll) {
+			return [];
+		}
+
+		const candidates = [...root.querySelectorAll(PRESSABLE_SELECTOR)];
+		const enclosing = root.closest?.(PRESSABLE_SELECTOR);
+
+		if (enclosing) {
+			candidates.push(enclosing);
+		}
+
+		const rects = [];
+
+		for (const element of candidates) {
+			if (element.closest(OWN_SURFACE_SELECTOR)) {
+				continue;
+			}
+
+			const box = element.ownerDocument.createRange();
+
+			try {
+				box.selectNode(element);
+			} catch {
+				continue;
+			}
+
+			rects.push(...getPageRectsForRange(box, source));
+		}
+
+		return rects;
+	}
+
 	// #endregion hnewhere-test-export
 
 	// #region hnewhere-test-export
@@ -20908,6 +20999,43 @@ title="Show only this discussion">
 			paintActiveLayer();
 		};
 
+		const pressRect = (group, rect) => {
+			const node = createHighlightRect(rect, {
+				interactive: true,
+				title: "Show the comments quoting this",
+				onActivate: () => {
+					openFocusedDiscussion(group.key).catch(console.error);
+				},
+				variant: "highlight",
+			});
+
+			node.addEventListener("pointerenter", () => {
+				if (hoverQuery?.matches !== false) {
+					setActiveGroup(group.key);
+				}
+			});
+
+			node.addEventListener("pointerleave", () => {
+				if (activeGroupKey === group.key) {
+					setActiveGroup(null);
+				}
+			});
+
+			node.addEventListener("focus", () => {
+				if (node.matches(":focus-visible")) {
+					setActiveGroup(group.key);
+				}
+			});
+
+			node.addEventListener("blur", () => {
+				if (activeGroupKey === group.key) {
+					setActiveGroup(null);
+				}
+			});
+
+			return node;
+		};
+
 		const render = () => {
 			overlay.style.height = source.heightFor(overlayHost) + "px";
 			baseLayer.replaceChildren();
@@ -20943,43 +21071,30 @@ title="Show only this discussion">
 				}
 
 				const groupRects = [];
+				const blockers = pressableRectsAround(group.range);
 
 				for (const rect of rects) {
-					const node = createHighlightRect(rect, {
-						interactive: true,
-						title: "Show the comments quoting this",
-						onActivate: () => {
-							openFocusedDiscussion(group.key).catch(console.error);
-						},
+					const pieces = subtractSpans(rect, blockers);
+
+					if (coversWholeRect(pieces, rect)) {
+						const node = pressRect(group, rect);
+
+						groupRects.push(node);
+						baseLayer.appendChild(node);
+						continue;
+					}
+
+					const fill = createHighlightRect(rect, {
+						interactive: false,
 						variant: "highlight",
 					});
 
-					node.addEventListener("pointerenter", () => {
-						if (hoverQuery?.matches !== false) {
-							setActiveGroup(group.key);
-						}
-					});
+					groupRects.push(fill);
+					baseLayer.appendChild(fill);
 
-					node.addEventListener("pointerleave", () => {
-						if (activeGroupKey === group.key) {
-							setActiveGroup(null);
-						}
-					});
-
-					node.addEventListener("focus", () => {
-						if (node.matches(":focus-visible")) {
-							setActiveGroup(group.key);
-						}
-					});
-
-					node.addEventListener("blur", () => {
-						if (activeGroupKey === group.key) {
-							setActiveGroup(null);
-						}
-					});
-
-					groupRects.push(node);
-					baseLayer.appendChild(node);
+					for (const piece of pieces) {
+						baseLayer.appendChild(pressRect(group, piece));
+					}
 				}
 
 				rectsByGroup.set(group.key, groupRects);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -4550,23 +4550,6 @@ button {
 	}
 	// #endregion hnewhere-test-export
 
-	function openNotepad(section) {
-		const body = section?.querySelector(".notepad-body");
-		const toggle = section?.querySelector(".notepad-toggle");
-
-		if (!section?.classList.contains("is-collapsed")) {
-			return;
-		}
-
-		section.classList.remove("is-collapsed");
-		toggle.textContent = "hide";
-		toggle.setAttribute("aria-expanded", "true");
-
-		if (body) {
-			body.style.maxHeight = body.scrollHeight ? `${body.scrollHeight}px` : "";
-		}
-	}
-
 	function startInlineNoteEdit(div, note) {
 		const text = div.querySelector(".text");
 
@@ -4593,77 +4576,10 @@ button {
 		settleNotepad(div);
 	}
 
-	function startNotepadDraft(section, body) {
-		const add = section.querySelector(".notepad-add");
-		const open = body.querySelector(".note-editor-draft:not([data-closing])");
-
-		if (open) {
-			closeNotepadDraft(section, body);
-			return;
-		}
-
-		openNotepad(section);
-
-		const held = inlineNoteEditor(null, {
-			canAnchor: (exact) => Boolean(anchorNoteQuote(exact)),
-
-			onSave: (parsed) => {
-				writeNote(parsed).catch(console.error);
-			},
-			onClose: () => closeNotepadDraft(section, body),
-		});
-
-		held.editor.classList.add("note-editor-draft");
-		body.prepend(held.editor);
-		add?.classList.add("is-open");
-		add?.setAttribute("aria-expanded", "true");
-
-		requestAnimationFrame(() => {
-			held.editor.classList.add("is-open");
-			held.editor.style.maxHeight = `${held.editor.scrollHeight}px`;
-			settleNotepad(held.editor);
-			held.field.focus({ preventScroll: true });
-
-			window.setTimeout(() => releaseNotepadDraft(held.editor), 240);
-		});
-	}
-
-	function releaseNotepadDraft(draft) {
-		if (!draft?.isConnected || !draft.classList.contains("is-open")) {
-			return;
-		}
-
-		draft.style.maxHeight = "none";
-		draft.style.overflow = "visible";
-		draft.scrollTop = 0;
-	}
-
 	function clampNotepadDraft(draft) {
 		draft.style.overflow = "";
 		draft.style.maxHeight = `${draft.scrollHeight}px`;
 		draft.getBoundingClientRect();
-	}
-
-	function closeNotepadDraft(section, body) {
-		const add = section.querySelector(".notepad-add");
-		const draft = body.querySelector(".note-editor-draft");
-
-		add?.classList.remove("is-open");
-		add?.setAttribute("aria-expanded", "false");
-
-		if (!draft) {
-			return;
-		}
-
-		draft.dataset.closing = "1";
-		clampNotepadDraft(draft);
-		draft.style.maxHeight = "0px";
-		draft.classList.remove("is-open");
-
-		window.setTimeout(() => {
-			draft.remove();
-			settleNotepad(body.firstElementChild || body);
-		}, 220);
 	}
 
 	async function writeNote(parsed) {
@@ -4730,11 +4646,6 @@ button {
 		);
 		body.replaceChildren();
 
-		const add = section.querySelector(".notepad-add");
-
-		add?.classList.remove("is-open");
-		add?.setAttribute("aria-expanded", "false");
-
 		toggle.hidden = empty;
 		toggle.textContent = empty ? "show" : "hide";
 		toggle.setAttribute("aria-expanded", empty ? "false" : "true");
@@ -4782,8 +4693,16 @@ button {
 			return;
 		}
 
-		control.hidden = !entries.some((entry) => entry.unread);
+		const unread = entries.some((entry) => entry.unread);
+
+		control.hidden = !unread;
 		control.classList.toggle("is-on", Boolean(settings.newCommentsFirst));
+
+		const separator = ui.shadow.querySelector("#sort-sep");
+
+		if (separator) {
+			separator.hidden = !unread;
+		}
 	}
 
 	function removeNoteAffordance() {
@@ -11754,7 +11673,13 @@ header button svg {
 	text-underline-offset:2px;
 }
 
-.page-sort-toggle[hidden] {
+.page-sort-sep {
+	margin:0 .1em;
+	color:var(--meta);
+}
+
+.page-sort-toggle[hidden],
+.page-sort-sep[hidden] {
 	display:none;
 }
 
@@ -13904,20 +13829,7 @@ ${SUBMIT_FORM_CSS}
 	margin-left:auto;
 }
 
-.notepad-add {
-	padding:0;
-	border:0;
-	background:none;
-	color:var(--meta);
-	font:inherit;
-	font-size:11px;
-	text-decoration:underline dotted;
-	text-underline-offset:2px;
-	cursor:pointer;
-}
-
 @media (hover: hover) {
-	.notepad-add:hover,
 	.notepad-toggle:hover {
 		text-decoration:underline;
 	}
@@ -13938,22 +13850,10 @@ ${SUBMIT_FORM_CSS}
 	display:none;
 }
 
-.notepad-toggle::before {
-	content:"|";
-	margin:0 .35em;
-	color:var(--meta);
-	text-decoration:none;
-	display:inline-block;
-}
-
 .notepad-body {
 	margin-left:8px;
 	overflow:hidden;
 	transition:max-height .22s ease, opacity .18s ease;
-}
-
-.notepad-add.is-open {
-	text-decoration:underline;
 }
 
 .note-editor-draft {
@@ -14614,13 +14514,201 @@ blockquote.comment-quote-redundant {
 	color:var(--link);
 }
 
-.story-body-cell > .comment-composer {
-	margin-left:calc(8px - var(--vote-column));
-}
-
 .comment-composer {
 	margin-top:10px;
 	max-width:720px;
+}
+
+.compose-box {
+	position:relative;
+	margin:0 0 14px 8px;
+}
+
+.compose-anchor {
+	height:0;
+}
+
+.compose-dock {
+	position:absolute;
+	top:8px;
+	left:50%;
+	transform:translateX(-50%);
+	width:calc(100% - 24px);
+	max-width:calc(100% - 24px);
+	pointer-events:auto;
+}
+
+.compose-dock[hidden] {
+	display:none;
+}
+
+.compose-dock-pill {
+	display:block;
+	margin:0 auto;
+	padding:6px 14px;
+	border:0;
+	border-radius:999px;
+	background:var(--accent);
+	color:var(--accent-ink);
+	box-shadow:0 4px 14px rgba(0,0,0,.22);
+	font:inherit;
+	font-size:12px;
+	line-height:1.4;
+	cursor:pointer;
+}
+
+.compose-dock-slot {
+	overflow:hidden;
+	max-height:0;
+	transition:max-height .22s ease;
+}
+
+.compose-dock.is-docked .compose-dock-pill {
+	margin-bottom:6px;
+	border-radius:6px 6px 0 0;
+	width:100%;
+}
+
+.compose-dock.is-docked .compose-dock-slot {
+	padding:0 0 8px;
+	border-radius:0 0 6px 6px;
+	background:var(--surface);
+	box-shadow:0 6px 18px rgba(0,0,0,.22);
+}
+
+.compose-dock .compose-box {
+	margin:0 8px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.compose-dock-slot {
+		transition:none;
+	}
+}
+
+.compose-field {
+	border:1px solid var(--field-border);
+	border-radius:6px;
+	background:var(--field-bg);
+}
+
+.compose-field:focus-within {
+	border-color:var(--accent);
+	box-shadow:0 0 0 2px rgba(var(--accent-rgb),.16);
+}
+
+.compose-field > .composer-text {
+	display:block;
+	width:100%;
+	min-height:0;
+	box-sizing:border-box;
+	padding:7px 9px 2px;
+	border:0;
+	border-radius:6px 6px 0 0;
+	background:none;
+	resize:vertical;
+}
+
+.compose-field > .composer-text:focus {
+	outline:none;
+	box-shadow:none;
+}
+
+.compose-field > .composer-actions {
+	display:flex;
+	align-items:center;
+	gap:8px;
+	padding:2px 7px 7px 9px;
+}
+
+.compose-send-row {
+	display:inline-flex;
+	gap:6px;
+	margin-left:auto;
+}
+
+.compose-send {
+	display:inline-flex;
+	align-items:center;
+	justify-content:center;
+	height:22px;
+	padding:0 10px;
+	border:0;
+	border-radius:999px;
+	font:inherit;
+	font-size:11px;
+	line-height:1;
+	cursor:pointer;
+	transition:opacity .15s ease, transform .15s ease;
+}
+
+.compose-send[hidden] {
+	display:none;
+}
+
+.compose-send:disabled {
+	opacity:.45;
+	cursor:default;
+}
+
+.compose-send-note {
+	color:var(--surface-text);
+	background:var(--hover-tint);
+}
+
+.compose-send-comment {
+	color:var(--accent-ink);
+	background:var(--accent);
+}
+
+@media (hover: hover) {
+	.compose-send:not(:disabled):hover {
+		transform:translateY(-1px);
+	}
+}
+
+.compose-send:focus-visible {
+	outline:2px solid var(--link);
+	outline-offset:2px;
+}
+
+.compose-targets {
+	position:absolute;
+	right:0;
+	top:calc(100% + 4px);
+	max-height:180px;
+	overflow-y:auto;
+	z-index:2;
+	display:flex;
+	flex-direction:column;
+	min-width:132px;
+	padding:4px;
+	border:1px solid var(--surface-border);
+	border-radius:6px;
+	background:var(--surface);
+	box-shadow:0 4px 14px rgba(0,0,0,.18);
+}
+
+.compose-targets.hidden {
+	display:none;
+}
+
+.compose-target {
+	padding:5px 8px;
+	border:0;
+	border-radius:4px;
+	background:none;
+	color:var(--surface-text);
+	font:inherit;
+	font-size:12px;
+	text-align:left;
+	cursor:pointer;
+}
+
+@media (hover: hover) {
+	.compose-target:hover {
+		background:var(--hover-tint);
+	}
 }
 
 .reply-composer {
@@ -14796,7 +14884,7 @@ blockquote.comment-quote-redundant {
 <div id="resize-handle" aria-hidden="true"></div>
 
 ${headerHTML({ subtitle: true, minimize: true, browse: true })}
-<div class="toast-layer"><div id="toast" class="toast" role="status" aria-live="polite"></div></div>
+<div class="toast-layer"><div id="toast" class="toast" role="status" aria-live="polite"></div><div id="compose-dock" class="compose-dock" hidden><button type="button" id="compose-dock-pill" class="compose-dock-pill"></button><div id="compose-dock-slot" class="compose-dock-slot"></div></div></div>
 ${settingsPanelHTML()}
 <div id="comments">
 <div id="filter-banner" class="filter-banner hidden">
@@ -15245,6 +15333,330 @@ ${settingsPanelHTML()}
 		COMMENT_BRIDGE_MESSAGE_SOURCE,
 	);
 
+	function wireComposeDock(ui, box, label) {
+		const dock = ui.shadow.querySelector("#compose-dock");
+		const pill = ui.shadow.querySelector("#compose-dock-pill");
+		const slot = ui.shadow.querySelector("#compose-dock-slot");
+		const root = ui.body?.closest("#comments");
+
+		if (!dock || !pill || !slot || !root || typeof IntersectionObserver !== "function") {
+			return null;
+		}
+
+		const anchorNode = document.createElement("div");
+
+		anchorNode.className = "compose-anchor";
+		box.parentElement.insertBefore(anchorNode, box);
+
+		const spacer = document.createElement("div");
+
+		spacer.className = "compose-spacer";
+		pill.textContent = label;
+
+		let docked = false;
+
+		const undock = () => {
+			if (!docked) {
+				return;
+			}
+
+			docked = false;
+			dock.classList.remove("is-open");
+			slot.style.maxHeight = "0px";
+			spacer.replaceWith(box);
+			dock.classList.remove("is-docked");
+		};
+
+		const dockBox = () => {
+			if (docked) {
+				return;
+			}
+
+			docked = true;
+			spacer.style.height = `${box.getBoundingClientRect().height}px`;
+			box.replaceWith(spacer);
+			slot.appendChild(box);
+			dock.classList.add("is-docked");
+
+			requestAnimationFrame(() => {
+				dock.classList.add("is-open");
+				slot.style.maxHeight = `${slot.scrollHeight}px`;
+				box.querySelector(".composer-text")?.focus({ preventScroll: true });
+			});
+		};
+
+		pill.onclick = () => (docked ? undock() : dockBox());
+
+		dock.addEventListener("keydown", (event) => {
+			if (event.key === "Escape") {
+				undock();
+			}
+		});
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					const gone = !entry.isIntersecting && entry.boundingClientRect.top < (entry.rootBounds?.top ?? 0);
+
+					dock.hidden = !gone;
+
+					if (!gone) {
+						undock();
+					}
+				}
+			},
+			{ root, threshold: 0 },
+		);
+
+		observer.observe(anchorNode);
+
+		return { undock, stop: () => observer.disconnect() };
+	}
+
+	function replyTargets(stories = renderedDiscussions || []) {
+		const filtered =
+			activeCommentFilter?.type === "discussion" ? activeCommentFilter.key : null;
+
+		return stories.filter(
+			(story) =>
+				getSource(story.source)?.capabilities.reply &&
+				(!filtered || story.key === filtered),
+		);
+	}
+
+	function syncComposeBox() {
+		const box = sidebarUI?.body?.querySelector(".compose-box");
+		const button = box?.querySelector(".compose-send-comment");
+
+		if (!box || !button) {
+			return;
+		}
+
+		const targets = replyTargets();
+		const canNote = Boolean(box.querySelector(".compose-send-note"));
+
+		button.hidden = targets.length === 0;
+
+		if (!targets.length) {
+			box.querySelector(".compose-targets")?.classList.add("hidden");
+		}
+
+		const field = box.querySelector(".composer-text");
+		const placeholder = composePlaceholder(targets.length > 0, canNote);
+
+		field.placeholder = placeholder;
+		field.setAttribute("aria-label", placeholder);
+	}
+
+	function mountComposeBox(ui, stories, settings, before) {
+		const canNote = Boolean(settings.notepad);
+		const canComment = stories.some(
+			(story) => getSource(story.source)?.capabilities.reply,
+		);
+
+		if (!canComment && !canNote) {
+			return null;
+		}
+
+		const holder = document.createElement("div");
+
+		holder.innerHTML = composeBoxHTML({
+			canComment,
+			canNote,
+			placeholder: composePlaceholder(canComment, canNote),
+		});
+
+		const box = holder.firstElementChild;
+
+		ui.body.insertBefore(box, before);
+
+		const textarea = box.querySelector(".composer-text");
+		const status = box.querySelector(".composer-status");
+
+		const grow = () => {
+			if (textarea.style.height) {
+				return;
+			}
+
+			const style = getComputedStyle(textarea);
+			const line = parseFloat(style.lineHeight) || 18;
+			const padding = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+
+			textarea.rows = 1;
+
+			const used = Math.max(
+				1,
+				Math.round((textarea.scrollHeight - padding) / line),
+			);
+
+			textarea.rows = Math.min(
+				COMPOSE_MAX_ROWS,
+				Math.max(textarea.dataset.opened ? 2 : 1, used + 1),
+			);
+		};
+
+		textarea.addEventListener("focus", () => {
+			textarea.dataset.opened = "1";
+			grow();
+		});
+		textarea.addEventListener("input", grow);
+		textarea.addEventListener("blur", () => {
+			delete textarea.dataset.opened;
+
+			if (!textarea.style.height) {
+				textarea.rows = 1;
+			}
+		});
+		const menu = box.querySelector(".compose-targets");
+		const first = stories[0];
+
+		const held = canComment
+			? wireComposer(box, {
+					source: first?.source || "hn",
+					storyID: first?.id,
+					onPosted: () => {},
+				})
+			: null;
+
+		const say = (message, error = false) => {
+			if (held) {
+				held.setStatus(message, { error });
+				return;
+			}
+
+			status.classList.toggle("hidden", !message);
+			status.classList.toggle("error", Boolean(error));
+			status.textContent = message || "";
+		};
+
+		const closeMenu = () => menu.classList.add("hidden");
+
+		if (canComment) {
+			const commentButton = box.querySelector(".compose-send-comment");
+
+			commentButton.onclick = () => {
+				const targets = replyTargets(stories);
+
+				if (!targets.length) {
+					return;
+				}
+
+				if (targets.length === 1) {
+					closeMenu();
+					box._hnewhereDock?.undock();
+					held.send({ source: targets[0].source, storyID: targets[0].id });
+					return;
+				}
+
+				if (!menu.classList.contains("hidden")) {
+					closeMenu();
+					return;
+				}
+
+				menu.replaceChildren(
+					...targets.map((story) => {
+						const choice = document.createElement("button");
+
+						choice.type = "button";
+						choice.className = "compose-target";
+						choice.textContent =
+							story.baseLabel || story.label || getSource(story.source)?.label || story.source;
+						choice.onclick = () => {
+							closeMenu();
+							box._hnewhereDock?.undock();
+							held.send({ source: story.source, storyID: story.id });
+						};
+
+						return choice;
+					}),
+				);
+				menu.classList.remove("hidden");
+			};
+		}
+
+		if (canNote) {
+			const noteButton = box.querySelector(".compose-send-note");
+			let warnedFor = null;
+
+			noteButton.onclick = () => {
+				closeMenu();
+
+				const parsed = noteFromText(textarea.value);
+
+				if (!parsed.text && !parsed.exact) {
+					say("Write something first.", true);
+					textarea.focus();
+					return;
+				}
+
+				if (parsed.exact && warnedFor !== parsed.exact && !anchorNoteQuote(parsed.exact)) {
+					warnedFor = parsed.exact;
+					say(
+						"Your quoted text wasn't found in this document. Press again to keep it without a highlight.",
+						true,
+					);
+					return;
+				}
+
+				textarea.value = "";
+				say("Kept");
+				box._hnewhereDock?.undock();
+				writeNote(parsed).catch(console.error);
+			};
+		}
+
+		syncComposeBox();
+
+		box._hnewhereDock = wireComposeDock(
+			ui,
+			box,
+			canComment ? "Add a comment" : "Keep a note",
+		);
+
+		return box;
+	}
+
+	const COMPOSE_MAX_ROWS = 12;
+
+	function composeBoxHTML({ canComment, canNote, placeholder }) {
+		return `
+	<div class="comment-composer compose-box">
+	<div class="compose-field">
+	<textarea class="composer-text" rows="1" placeholder="${escapeHTML(placeholder)}" aria-label="${escapeHTML(placeholder)}"></textarea>
+	<div class="composer-actions">
+	${canComment ? `<button type="button" class="composer-help-toggle" aria-expanded="false">formatting</button>` : ""}
+	<div class="composer-status hidden" role="status"></div>
+	<span class="compose-send-row">${
+		canNote
+			? `<button type="button" class="compose-send compose-send-note" title="Keep this as a note">note</button>`
+			: ""
+	}${
+		canComment
+			? `<button type="submit" class="composer-submit compose-send compose-send-comment" title="Add this as a comment">comment</button>`
+			: ""
+	}</span>
+	</div>
+	</div>
+	<div class="compose-targets hidden" role="menu"></div>
+	<div class="composer-help hidden">
+	<p>Blank lines separate paragraphs.</p>
+	<p>Text surrounded by asterisks is italicized. To get a literal asterisk, use <code>\\*</code> or <code>**</code>.</p>
+	<p>Text after a blank line that is indented by two or more spaces is formatted as code.</p>
+	<p>Urls become links, except in the text field of a submission.</p>
+	<p>If your url gets linked incorrectly, put it in <code>&lt;angle brackets&gt;</code> and it should work.</p>
+	</div>
+	</div>
+`;
+	}
+
+	function composePlaceholder(canComment, canNote) {
+		if (canComment && canNote) {
+			return "Add a comment, or keep a note\u2026";
+		}
+
+		return canComment ? "Add a comment\u2026" : "Keep a note\u2026";
+	}
+
 	function composerHTML({ label, placeholder }) {
 		return `
 	<div class="comment-composer">
@@ -15390,56 +15802,55 @@ ${settingsPanelHTML()}
 			submitButton.textContent = busy ? submitLabel + "…" : submitLabel;
 		};
 
-		submitButton.onclick = async () => {
+		const send = (aim = {}) => {
+			const toSource = aim.source || source;
+			const toStory = aim.storyID ?? storyID;
 			const text = textarea.value;
+			const label = getSource(toSource)?.label || "the source";
 
 			if (!text.trim()) {
 				setStatus("Write something first.", { error: true });
 				textarea.focus();
-				return;
+				return Promise.resolve();
 			}
 
 			setBusy(true);
 			showSpinner();
 
-			try {
-				const result = await submitCommentThroughBridge(
-					source,
-					storyID,
-					text,
-					parentId,
-					() =>
-						setStatus(
-							`Waiting for sign-in on ${getSource(source)?.label || "the source"}…`,
-						),
-				);
+			const posting = submitCommentThroughBridge(toSource, toStory, text, parentId, () =>
+				setStatus(`Waiting for sign-in on ${label}…`),
+			);
 
-				await rememberAuthFromResult(source, result);
+			return (async () => {
+				try {
+					const result = await posting;
 
-				if (!result?.ok) {
-					setStatus(
-						commentFailureMessage(result, getSource(source)?.label || "the source"),
-						{ error: true },
-					);
-					return;
+					await rememberAuthFromResult(toSource, result);
+
+					if (!result?.ok) {
+						setStatus(commentFailureMessage(result, label), { error: true });
+						return;
+					}
+
+					textarea.value = "";
+					clearTimeout(saveTimer);
+					await save(draftKey, null);
+
+					setStatus("Posted");
+
+					window.setTimeout(() => {
+						onPosted?.();
+						reloadDiscussion(toStory);
+					}, 1400);
+				} finally {
+					setBusy(false);
 				}
-
-				textarea.value = "";
-				clearTimeout(saveTimer);
-				await save(draftKey, null);
-
-				setStatus("Posted");
-
-				window.setTimeout(() => {
-					onPosted?.();
-					reloadDiscussion(storyID);
-				}, 1400);
-			} finally {
-				setBusy(false);
-			}
+			})();
 		};
 
-		return { focus: () => textarea.focus() };
+		submitButton.onclick = () => send();
+
+		return { focus: () => textarea.focus(), send, setStatus, textarea };
 	}
 
 	function submitCommentThroughBridge(
@@ -16387,10 +16798,9 @@ ${settingsPanelHTML()}
 		const disambiguating = stories.length > 1;
 
 		for (const story of stories) {
-			const canReply = Boolean(getSource(story.source)?.capabilities.reply);
 			const resolved = storyTitle(story, page, disambiguating);
 			const block = renderStory(story, details, {
-				compose: canReply,
+				compose: false,
 				title: resolved,
 				showTitle: true,
 				watchable: !disambiguating,
@@ -16414,6 +16824,8 @@ ${settingsPanelHTML()}
 			ui.body.insertBefore(sortRow, comments);
 		}
 
+		mountComposeBox(ui, stories, settings, sortRow || comments);
+
 		const collapsedKeys = await loadCollapsed();
 		const seenTimes = new Map(
 			await Promise.all(
@@ -16424,11 +16836,8 @@ ${settingsPanelHTML()}
 		const notes = settings.notepad ? await loadNotes() : [];
 		const notesDiscussion = notesCollective(notes, pageAddress());
 
-		if (settings.notepad) {
-			const held = notesSection({
-				empty: !notes.length,
-				onAdd: () => startNotepadDraft(held.section, held.body),
-			});
+		if (settings.notepad && notes.length) {
+			const held = notesSection({ empty: false });
 
 			const storyCell = disambiguating
 				? null
@@ -16443,7 +16852,9 @@ ${settingsPanelHTML()}
 			} else {
 				ui.body.insertBefore(
 					held.section,
-					ui.body.querySelector(".page-sort") || comments,
+					ui.body.querySelector(".compose-box") ||
+						ui.body.querySelector(".page-sort") ||
+						comments,
 				);
 			}
 
@@ -16671,7 +17082,7 @@ ${settingsPanelHTML()}
 	}
 
 	// #region hnewhere-test-export
-	function notesSection({ onAdd, empty = false } = {}) {
+	function notesSection({ empty = false } = {}) {
 		const section = document.createElement("div");
 		const head = document.createElement("div");
 		const body = document.createElement("div");
@@ -16717,15 +17128,10 @@ ${settingsPanelHTML()}
 			}
 		};
 
-		add.type = "button";
-		add.className = "notepad-add";
-		add.textContent = "add a note";
-		add.onclick = () => onAdd?.(add);
-
 		const actions = document.createElement("span");
 
 		actions.className = "notepad-actions";
-		actions.append(add, toggle);
+		actions.append(toggle);
 		head.append(actions);
 		body.className = "notepad-body";
 		foot.className = "notepad-rule notepad-rule-close";
@@ -16856,6 +17262,7 @@ ${settingsPanelHTML()}
 			(mode) =>
 				`<option value="${mode.id}"${mode.id === sort ? " selected" : ""}>${mode.label}</option>`,
 		).join("")}</select>
+<span id="sort-sep" class="page-sort-sep" hidden>|</span>
 <button id="sort-new-first" class="page-sort-toggle" type="button" hidden>prioritize unread</button>`;
 
 		sortRow.querySelector("#sort-new-first").onclick = async (event) => {
@@ -17048,6 +17455,7 @@ title="Show only this discussion">
 
 		syncSubmissionDetails();
 		syncSourceBadges();
+		syncComposeBox();
 	}
 
 	function syncSourceBadges() {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -14758,7 +14758,7 @@ blockquote.comment-quote-redundant {
 	cursor:default;
 }
 
-.compose-send:disabled.is-working {
+.compose-send:disabled.is-sending {
 	opacity:1;
 }
 
@@ -15583,6 +15583,18 @@ ${settingsPanelHTML()}
 		button?.setAttribute("aria-expanded", "false");
 	}
 
+	function syncComposeSendable(box) {
+		const written = Boolean(
+			box.querySelector(".composer-text")?.value.trim(),
+		);
+
+		for (const button of box.querySelectorAll(".compose-send")) {
+			if (!button.dataset.sending) {
+				button.disabled = !written;
+			}
+		}
+	}
+
 	function syncComposeBox() {
 		const box =
 			sidebarUI?.body?.querySelector(".compose-box") ||
@@ -15672,6 +15684,7 @@ ${settingsPanelHTML()}
 			grow();
 		});
 		textarea.addEventListener("input", grow);
+		textarea.addEventListener("input", () => syncComposeSendable(box));
 		textarea.addEventListener("blur", () => {
 			delete textarea.dataset.opened;
 
@@ -15721,7 +15734,9 @@ ${settingsPanelHTML()}
 				if (targets.length === 1) {
 					closeMenu();
 					box._hnewhereDock?.undock();
-					held.send({ source: targets[0].source, storyID: targets[0].id });
+					held
+						.send({ source: targets[0].source, storyID: targets[0].id })
+						.finally(() => syncComposeSendable(box));
 					return;
 				}
 
@@ -15741,13 +15756,15 @@ ${settingsPanelHTML()}
 						choice.onclick = () => {
 							closeMenu();
 							box._hnewhereDock?.undock();
-							held.send({ source: story.source, storyID: story.id });
+							held
+								.send({ source: story.source, storyID: story.id })
+								.finally(() => syncComposeSendable(box));
 						};
 
 						return choice;
 					}),
 				);
-				menu.classList.remove("hidden");
+				openMenu();
 			};
 		}
 
@@ -15779,12 +15796,14 @@ ${settingsPanelHTML()}
 				say("");
 				box._hnewhereDock?.undock();
 				startComposeSend(noteButton, "saving…", "saved");
+				syncComposeSendable(box);
 				writeNote(parsed)
 					.then(() => settleComposeSend(noteButton, "saved"))
 					.catch((error) => {
 						restComposeSend(noteButton);
 						console.error(error);
-					});
+					})
+					.finally(() => syncComposeSendable(box));
 			};
 		}
 
@@ -15804,6 +15823,7 @@ ${settingsPanelHTML()}
 		}
 
 		syncComposeBox();
+		syncComposeSendable(box);
 
 		box._hnewhereDock = wireComposeDock(ui, box, composeDockLabel(canComment));
 
@@ -15927,7 +15947,7 @@ ${settingsPanelHTML()}
 		button.dataset.sending = "1";
 		button.dataset.sendAt = String(Date.now());
 		button.classList.remove("is-fading");
-		button.classList.add("is-working");
+		button.classList.add("is-sending", "is-working");
 		label.textContent = working;
 	}
 
@@ -15962,7 +15982,7 @@ ${settingsPanelHTML()}
 		button.classList.remove("is-working");
 
 		if (rest === undefined || label.textContent === rest) {
-			button.classList.remove("is-fading");
+			button.classList.remove("is-fading", "is-sending");
 			return;
 		}
 
@@ -15971,7 +15991,7 @@ ${settingsPanelHTML()}
 			button,
 			window.setTimeout(() => {
 				label.textContent = rest;
-				button.classList.remove("is-fading");
+				button.classList.remove("is-fading", "is-sending");
 			}, 170),
 		);
 	}

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -8067,6 +8067,7 @@ button {
 
 	function buttonVoteDescriptors(voteInfo, label) {
 		const state = voteInfo?.state || "none";
+		const voted = state === "up" || state === "down";
 
 		return [
 			{
@@ -8075,6 +8076,7 @@ button {
 				action: state === "up" ? "un" : "up",
 				url: null,
 				active: state === "up",
+				muted: voted && state !== "up",
 				variant: "up",
 			},
 			{
@@ -8084,6 +8086,7 @@ button {
 				action: state === "down" ? "un" : "down",
 				url: null,
 				active: state === "down",
+				muted: voted && state !== "down",
 				variant: "down",
 			},
 		];
@@ -8444,6 +8447,10 @@ button {
 
 			if (descriptor.active) {
 				button.classList.add("vote-button-active");
+			}
+
+			if (descriptor.muted) {
+				button.classList.add("vote-button-muted");
 			}
 
 			if (descriptor.variant) {
@@ -13359,6 +13366,7 @@ ${[
 
 #panel {
 	all:initial;
+	--vote-column:17px;
 	line-height:1.4;
 	color-scheme:inherit;
 	-webkit-text-size-adjust:100%;
@@ -14066,7 +14074,7 @@ ${SUBMIT_FORM_CSS}
 
 .story-votelinks,
 .story-votespacer {
-	width:14px;
+	width:var(--vote-column);
 }
 
 .story-votelinks {
@@ -14097,8 +14105,8 @@ ${SUBMIT_FORM_CSS}
 }
 
 .comment-vote-slot {
-	flex:0 0 17px;
-	width:17px;
+	flex:0 0 var(--vote-column);
+	width:var(--vote-column);
 	display:flex;
 	flex-direction:column;
 	align-items:center;
@@ -14195,6 +14203,16 @@ ${SUBMIT_FORM_CSS}
 
 .vote-button-neutral::before {
 	content:none;
+}
+
+.vote-button-muted {
+	opacity:.33;
+}
+
+@media (hover: hover) {
+	.vote-button-muted:hover {
+		opacity:1;
+	}
 }
 
 .vote-button-neutral.vote-button-active {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -4782,15 +4782,8 @@ button {
 			return;
 		}
 
-		const unread = entries.some((entry) => entry.unread);
-		const row = control.closest(".page-sort");
-
-		control.hidden = !unread;
+		control.hidden = !entries.some((entry) => entry.unread);
 		control.classList.toggle("is-on", Boolean(settings.newCommentsFirst));
-
-		if (row?.classList.contains("page-sort-bare")) {
-			row.hidden = !unread;
-		}
 	}
 
 	function removeNoteAffordance() {
@@ -11761,8 +11754,7 @@ header button svg {
 	text-underline-offset:2px;
 }
 
-.page-sort-toggle[hidden],
-.page-sort[hidden] {
+.page-sort-toggle[hidden] {
 	display:none;
 }
 
@@ -16855,20 +16847,16 @@ ${settingsPanelHTML()}
 		liveBookendObservers.set(names, observer);
 	}
 
-	function mountSortRow(container, sort, options, withSort) {
+	function mountSortRow(container, sort, options) {
 		const sortRow = document.createElement("div");
 
-		sortRow.className = withSort ? "page-sort" : "page-sort page-sort-bare";
-		sortRow.innerHTML = `${
-			withSort
-				? `<label class="page-sort-label" for="comment-sort">Sort</label>
+		sortRow.className = "page-sort";
+		sortRow.innerHTML = `<label class="page-sort-label" for="comment-sort">Sort</label>
 <select class="page-sort-select" id="comment-sort">${SORT_MODES.map(
-						(mode) =>
-							`<option value="${mode.id}"${mode.id === sort ? " selected" : ""}>${mode.label}</option>`,
-					).join("")}</select>
-`
-				: ""
-		}<button id="sort-new-first" class="page-sort-toggle" type="button" hidden>prioritize unread</button>`;
+			(mode) =>
+				`<option value="${mode.id}"${mode.id === sort ? " selected" : ""}>${mode.label}</option>`,
+		).join("")}</select>
+<button id="sort-new-first" class="page-sort-toggle" type="button" hidden>prioritize unread</button>`;
 
 		sortRow.querySelector("#sort-new-first").onclick = async (event) => {
 			const control = event.currentTarget;
@@ -16882,25 +16870,19 @@ ${settingsPanelHTML()}
 			}
 		};
 
-		if (withSort) {
-			sortRow.querySelector(".page-sort-select").onchange = async (event) => {
-				const next = event.target.value;
+		sortRow.querySelector(".page-sort-select").onchange = async (event) => {
+			const next = event.target.value;
 
-				if (next === sort) {
-					return;
-				}
+			if (next === sort) {
+				return;
+			}
 
-				await saveSettings({ commentSort: next });
+			await saveSettings({ commentSort: next });
 
-				if (typeof options.onSortChange === "function") {
-					await options.onSortChange(next);
-				}
-			};
-		}
-
-		if (!withSort) {
-			sortRow.hidden = true;
-		}
+			if (typeof options.onSortChange === "function") {
+				await options.onSortChange(next);
+			}
+		};
 
 		container.appendChild(sortRow);
 	}
@@ -16964,7 +16946,7 @@ title="Show only this discussion">
 
 		if (!disclosure) {
 			container.appendChild(wrapper);
-			mountSortRow(container, sort, options, false);
+			mountSortRow(container, sort, options);
 
 			return wrapper;
 		}
@@ -17014,7 +16996,7 @@ title="Show only this discussion">
 
 		container.appendChild(wrapper);
 
-		mountSortRow(container, sort, options, true);
+		mountSortRow(container, sort, options);
 
 		return wrapper;
 	}

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -14110,9 +14110,23 @@ ${SUBMIT_FORM_CSS}
 	content:"";
 	flex:1 0 0;
 	width:1px;
+	min-height:7px;
 	margin-top:3px;
 	background:var(--border-soft);
-	transition:background-color .9s ease;
+	transform-origin:top;
+	transition:background-color .9s ease, transform .18s ease;
+}
+
+.comment:has(> .comment-layout > .comment-main > .comment-content.hidden)
+	> .comment-layout > .comment-vote-slot::after {
+	min-height:0;
+	transform:scaleY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.comment-vote-slot::after {
+		transition:background-color .9s ease;
+	}
 }
 
 .comment-main {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -13920,7 +13920,15 @@ ${SUBMIT_FORM_CSS}
 }
 
 .notepad-section {
-	margin:0 0 12px;
+	margin:0 0 15px;
+}
+
+.notepad-section.is-collapsed .notepad-rule {
+	padding-top:0;
+}
+
+.notepad-section.is-collapsed .notepad-rule-close {
+	display:none;
 }
 
 .notepad-rule {
@@ -13942,7 +13950,7 @@ ${SUBMIT_FORM_CSS}
 }
 
 .notepad-rule-close {
-	padding-top:12px;
+	padding-top:15px;
 }
 
 .notepad-mark {
@@ -14657,7 +14665,7 @@ blockquote.comment-quote-redundant {
 
 .compose-box {
 	position:relative;
-	margin:14px 0 14px 8px;
+	margin:15px 0 15px 8px;
 }
 
 .compose-anchor {

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -5240,8 +5240,15 @@ button {
 		);
 	}
 
+	function canNotify() {
+		return (
+			typeof Notification !== "undefined" &&
+			typeof Notification.requestPermission === "function"
+		);
+	}
+
 	async function grantNotifications() {
-		if (typeof Notification === "undefined") {
+		if (!canNotify()) {
 			return false;
 		}
 
@@ -11951,7 +11958,7 @@ header button svg {
 }
 
 .settings-option-hint {
-	margin:3px 0 0 21px;
+	margin:3px 0 0 23px;
 	color:var(--muted);
 	font-size:11px;
 	line-height:1.35;
@@ -11987,7 +11994,7 @@ header button svg {
 }
 
 .settings-option.sub-option + .settings-option-hint {
-	margin-left:41px;
+	margin-left:43px;
 }
 
 .op-pill {
@@ -13010,6 +13017,19 @@ ${[
 
 				if (notice) {
 					notice.hidden = false;
+				}
+			}
+
+			if (!canNotify()) {
+				const option = settingsInputs.notifyOnWatch?.closest(".settings-option");
+				const hint = option?.nextElementSibling;
+
+				if (option) {
+					option.hidden = true;
+				}
+
+				if (hint?.classList.contains("settings-option-hint")) {
+					hint.hidden = true;
 				}
 			}
 		};

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -13802,7 +13802,7 @@ ${SUBMIT_FORM_CSS}
 }
 
 .notepad-section {
-	margin:0 0 6px;
+	margin:0 0 12px;
 }
 
 .notepad-rule {
@@ -13821,6 +13821,26 @@ ${SUBMIT_FORM_CSS}
 	flex:1 0 24px;
 	height:1px;
 	background:var(--surface-border);
+}
+
+.notepad-section-inline {
+	margin-top:14px;
+}
+
+.notepad-section-inline::before {
+	content:"";
+	display:block;
+	height:1px;
+	margin:0 0 0 calc(8px - var(--vote-column));
+	background:var(--surface-border);
+}
+
+.notepad-section-inline .notepad-rule {
+	margin-left:calc(-12px - var(--vote-column));
+}
+
+.notepad-section-inline .notepad-body {
+	margin-left:calc(8px - var(--vote-column));
 }
 
 .notepad-rule-close {
@@ -13850,7 +13870,8 @@ ${SUBMIT_FORM_CSS}
 	color:var(--meta);
 	font:inherit;
 	font-size:11px;
-	text-decoration:none;
+	text-decoration:underline dotted;
+	text-underline-offset:2px;
 	cursor:pointer;
 }
 
@@ -13885,6 +13906,7 @@ ${SUBMIT_FORM_CSS}
 }
 
 .notepad-body {
+	margin-left:8px;
 	overflow:hidden;
 	transition:max-height .22s ease, opacity .18s ease;
 }
@@ -16363,10 +16385,22 @@ ${settingsPanelHTML()}
 				onAdd: () => startNotepadDraft(held.section, held.body),
 			});
 
-			ui.body.insertBefore(
-				held.section,
-				ui.body.querySelector(".page-sort") || comments,
-			);
+			const storyCell = disambiguating
+				? null
+				: ui.body.querySelector(".submission-detail .story-body-cell");
+
+			if (storyCell) {
+				held.section.classList.add("notepad-section-inline");
+				storyCell.insertBefore(
+					held.section,
+					storyCell.querySelector(".comment-composer"),
+				);
+			} else {
+				ui.body.insertBefore(
+					held.section,
+					ui.body.querySelector(".page-sort") || comments,
+				);
+			}
 
 			if (notesDiscussion) {
 				const thread = notesThread(notesDiscussion);

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -10539,6 +10539,10 @@ ${submitTarget ? `<button id="submit-go" type="button" class="primary">Submit</b
 	--header-text:#fff;
 	--subtitle-stage:#c2e0cd;
 	--subtitle-stage-peak:#ffffff;
+	--send-ink-stage:rgba(255,255,255,.5);
+	--send-ink-peak:#ffffff;
+	--send-note-stage:rgba(34,34,34,.38);
+	--send-note-peak:#222222;
 	--border:#ccc;
 	--border-soft:#ddd;
 	--link:#0000aa;
@@ -10587,6 +10591,10 @@ ${submitTarget ? `<button id="submit-go" type="button" class="primary">Submit</b
 	--header-text:#f0fff5;
 	--subtitle-stage:#8fbda2;
 	--subtitle-stage-peak:#e6fff0;
+	--send-ink-stage:rgba(0,0,0,.45);
+	--send-ink-peak:#000000;
+	--send-note-stage:rgba(220,220,220,.38);
+	--send-note-peak:#dcdcdc;
 	--border:#3d3d3d;
 	--border-soft:#383838;
 	--link:#8ab4f8;
@@ -14690,6 +14698,49 @@ blockquote.comment-quote-redundant {
 	cursor:default;
 }
 
+.compose-send:disabled.is-working {
+	opacity:1;
+}
+
+.compose-send-label {
+	display:inline-block;
+	--send-stage:var(--send-note-stage);
+	--send-peak:var(--send-note-peak);
+	transition:opacity .16s ease;
+}
+
+.is-fading > .compose-send-label {
+	opacity:0;
+}
+
+.is-working > .compose-send-label {
+	background-image:linear-gradient(
+		90deg,
+		var(--send-stage) 0%,
+		var(--send-stage) 40%,
+		var(--send-peak) 50%,
+		var(--send-stage) 60%,
+		var(--send-stage) 100%
+	);
+	background-size:220% 100%;
+	-webkit-background-clip:text;
+	background-clip:text;
+	-webkit-text-fill-color:transparent;
+	color:transparent;
+	animation:hnewhere-subtitle-shimmer 1.6s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.is-working > .compose-send-label {
+		animation:none;
+	}
+}
+
+.compose-send-comment > .compose-send-label {
+	--send-stage:var(--send-ink-stage);
+	--send-peak:var(--send-ink-peak);
+}
+
 .compose-send-note {
 	color:var(--surface-text);
 	background:var(--hover-tint);
@@ -14871,13 +14922,6 @@ blockquote.comment-quote-redundant {
 
 .composer-status.error {
 	color:var(--error);
-}
-
-.composer-spinner {
-	display:inline-block;
-	width:1em;
-	font-family:Menlo, Consolas, monospace;
-	color:var(--meta);
 }
 
 .composer-status a {
@@ -15649,10 +15693,30 @@ ${settingsPanelHTML()}
 				}
 
 				textarea.value = "";
-				say("Kept");
+				say("");
 				box._hnewhereDock?.undock();
-				writeNote(parsed).catch(console.error);
+				startComposeSend(noteButton, "saving…", "saved");
+				writeNote(parsed)
+					.then(() => settleComposeSend(noteButton, "saved"))
+					.catch((error) => {
+						restComposeSend(noteButton);
+						console.error(error);
+					});
 			};
+		}
+
+		if (canNote) {
+			holdComposeSendWidth(box.querySelector(".compose-send-note"), [
+				"saving…",
+				"saved",
+			]);
+		}
+
+		if (canComment) {
+			holdComposeSendWidth(box.querySelector(".compose-send-comment"), [
+				"posting…",
+				"posted",
+			]);
 		}
 
 		syncComposeBox();
@@ -15674,11 +15738,11 @@ ${settingsPanelHTML()}
 	<div class="composer-status hidden" role="status"></div>
 	<span class="compose-send-row">${
 		canNote
-			? `<button type="button" class="compose-send compose-send-note" title="Keep this as a note">note</button>`
+			? `<button type="button" class="compose-send compose-send-note" title="Keep this as a note"><span class="compose-send-label">note</span></button>`
 			: ""
 	}${
 		canComment
-			? `<button type="submit" class="composer-submit compose-send compose-send-comment" title="Add this as a comment">comment</button>`
+			? `<button type="submit" class="composer-submit compose-send compose-send-comment" title="Add this as a comment"><span class="compose-send-label">comment</span></button>`
 			: ""
 	}</span>
 	</div>
@@ -15727,19 +15791,106 @@ ${settingsPanelHTML()}
 		return "HNewhere:comment_draft:" + (parentId || storyID);
 	}
 
-	const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+	const composeSendRest = new WeakMap();
+	const composeSendTimers = new WeakMap();
 
-	function startSpinner(element) {
-		let frame = 0;
+	function composeSendLabel(button) {
+		let label = button.querySelector(".compose-send-label");
 
-		element.textContent = SPINNER_FRAMES[0];
+		if (!label) {
+			label = document.createElement("span");
+			label.className = "compose-send-label";
+			label.textContent = button.textContent;
+			button.replaceChildren(label);
+		}
 
-		const timer = window.setInterval(() => {
-			frame = (frame + 1) % SPINNER_FRAMES.length;
-			element.textContent = SPINNER_FRAMES[frame];
-		}, 90);
+		return label;
+	}
 
-		return () => window.clearInterval(timer);
+	const COMPOSE_SEND_HOLD = 450;
+
+	function holdComposeSendWidth(button, words) {
+		if (button.dataset.sized) {
+			return;
+		}
+
+		const label = composeSendLabel(button);
+		const rest = label.textContent;
+		let widest = button.getBoundingClientRect().width;
+
+		for (const word of words) {
+			label.textContent = word;
+			widest = Math.max(widest, button.getBoundingClientRect().width);
+		}
+
+		label.textContent = rest;
+
+		if (widest > 0) {
+			button.style.minWidth = `${Math.ceil(widest)}px`;
+			button.dataset.sized = "1";
+		}
+	}
+
+	function startComposeSend(button, working, done) {
+		const label = composeSendLabel(button);
+
+		window.clearTimeout(composeSendTimers.get(button));
+
+		if (!composeSendRest.has(button)) {
+			composeSendRest.set(button, label.textContent);
+		}
+
+		holdComposeSendWidth(button, [working, done]);
+		button.dataset.sending = "1";
+		button.dataset.sendAt = String(Date.now());
+		button.classList.remove("is-fading");
+		button.classList.add("is-working");
+		label.textContent = working;
+	}
+
+	function settleComposeSend(button, done) {
+		delete button.dataset.sending;
+
+		const held = Math.max(
+			0,
+			COMPOSE_SEND_HOLD - (Date.now() - Number(button.dataset.sendAt || 0)),
+		);
+
+		window.clearTimeout(composeSendTimers.get(button));
+		composeSendTimers.set(
+			button,
+			window.setTimeout(() => {
+				button.classList.remove("is-working");
+				composeSendLabel(button).textContent = done;
+				composeSendTimers.set(
+					button,
+					window.setTimeout(() => restComposeSend(button), 1100),
+				);
+			}, held),
+		);
+	}
+
+	function restComposeSend(button) {
+		const label = composeSendLabel(button);
+		const rest = composeSendRest.get(button);
+
+		delete button.dataset.sending;
+		window.clearTimeout(composeSendTimers.get(button));
+		button.classList.remove("is-working");
+
+		if (rest === undefined || label.textContent === rest) {
+			button.classList.remove("is-fading");
+			return;
+		}
+
+		button.classList.add("is-fading");
+		composeSendTimers.set(
+			button,
+			window.setTimeout(() => {
+				label.textContent = rest;
+				button.classList.remove("is-fading");
+			}, 170),
+		);
 	}
 
 	function wireComposer(
@@ -15753,18 +15904,13 @@ ${settingsPanelHTML()}
 		const draftKey = composerDraftKey({ storyID, parentId });
 		const textarea = composer.querySelector(".composer-text");
 		const submitButton = composer.querySelector(".composer-submit");
-		const submitLabel = submitButton.textContent;
 		const helpToggle = composer.querySelector(".composer-help-toggle");
 		const help = composer.querySelector(".composer-help");
 		const status = composer.querySelector(".composer-status");
 
-		let stopSpinner = null;
 		let swapTimer = 0;
 
 		const setStatus = (message, { error = false, html = false } = {}) => {
-			stopSpinner?.();
-			stopSpinner = null;
-
 			clearTimeout(swapTimer);
 
 			const write = () => {
@@ -15797,26 +15943,6 @@ ${settingsPanelHTML()}
 			}, 140);
 		};
 
-		const showSpinner = (label) => {
-			clearTimeout(swapTimer);
-			stopSpinner?.();
-
-			status.classList.remove("hidden", "error");
-			status.replaceChildren();
-
-			const spinner = document.createElement("span");
-
-			spinner.className = "composer-spinner";
-			status.appendChild(spinner);
-
-			if (label) {
-				status.appendChild(document.createTextNode(" " + label));
-			}
-
-			status.classList.remove("is-fading");
-			stopSpinner = startSpinner(spinner);
-		};
-
 		helpToggle.onclick = () => {
 			const hidden = help.classList.toggle("hidden");
 
@@ -15845,7 +15971,12 @@ ${settingsPanelHTML()}
 		const setBusy = (busy) => {
 			submitButton.disabled = busy;
 			textarea.disabled = busy;
-			submitButton.textContent = busy ? submitLabel + "…" : submitLabel;
+
+			if (busy) {
+				startComposeSend(submitButton, "posting…", "posted");
+			} else if (submitButton.dataset.sending) {
+				restComposeSend(submitButton);
+			}
 		};
 
 		const send = (aim = {}) => {
@@ -15861,7 +15992,6 @@ ${settingsPanelHTML()}
 			}
 
 			setBusy(true);
-			showSpinner();
 
 			const posting = submitCommentThroughBridge(toSource, toStory, text, parentId, () =>
 				setStatus(`Waiting for sign-in on ${label}…`),
@@ -15874,6 +16004,7 @@ ${settingsPanelHTML()}
 					await rememberAuthFromResult(toSource, result);
 
 					if (!result?.ok) {
+						restComposeSend(submitButton);
 						setStatus(commentFailureMessage(result, label), { error: true });
 						return;
 					}
@@ -15882,7 +16013,7 @@ ${settingsPanelHTML()}
 					clearTimeout(saveTimer);
 					await save(draftKey, null);
 
-					setStatus("Posted");
+					settleComposeSend(submitButton, "posted");
 
 					window.setTimeout(() => {
 						onPosted?.();

--- a/HNewhere.user.js
+++ b/HNewhere.user.js
@@ -4628,29 +4628,79 @@ button {
 		await reopenForNotes();
 	}
 
-	async function refreshNotepadInPlace() {
-		const section = sidebarUI?.body?.querySelector("[data-notes-section]");
-		const body = section?.querySelector(".notepad-body");
+	function placeNotesSection(ui, section) {
+		const storyCell = ui.body?.querySelector(".submission-detail .story-body-cell");
 
-		if (!body) {
+		if (storyCell && !storyCell.closest("[hidden]")) {
+			section.classList.add("notepad-section-inline");
+			storyCell.insertBefore(section, storyCell.querySelector(".compose-box"));
+			return;
+		}
+
+		section.classList.remove("notepad-section-inline");
+		ui.body.insertBefore(
+			section,
+			ui.body.querySelector(".compose-box") ||
+				ui.body.querySelector(".page-sort") ||
+				ui.body.querySelector(".top-level-comments"),
+		);
+	}
+
+	function retireNotesSection(section) {
+		const body = section.querySelector(".notepad-body");
+
+		if (prefersReducedMotion()) {
+			section.remove();
+			return;
+		}
+
+		section.style.overflow = "hidden";
+		section.style.maxHeight = `${section.scrollHeight}px`;
+
+		if (body) {
+			body.style.maxHeight = "0px";
+		}
+
+		requestAnimationFrame(() => {
+			section.style.transition = "max-height .22s ease, opacity .18s ease";
+			section.style.maxHeight = "0px";
+			section.style.opacity = "0";
+			window.setTimeout(() => section.remove(), 260);
+		});
+	}
+
+	async function refreshNotepadInPlace() {
+		if (!sidebarUI?.body) {
 			return false;
 		}
 
-		const notes = await loadNotes();
+		const settings = await loadSettings();
+		const notes = settings.notepad ? await loadNotes() : [];
+		let section = sidebarUI.body.querySelector("[data-notes-section]");
+
+		if (!notes.length) {
+			if (section) {
+				renderedComments = renderedComments.filter(
+					(rendered) => !section.contains(rendered.element),
+				);
+				retireNotesSection(section);
+			}
+
+			return true;
+		}
+
+		if (!section) {
+			section = notesSection({ empty: false }).section;
+			placeNotesSection(sidebarUI, section);
+		}
+
+		const body = section.querySelector(".notepad-body");
 		const discussion = notesCollective(notes, pageAddress());
-		const toggle = section.querySelector(".notepad-toggle");
-		const empty = !notes.length;
 
 		renderedComments = renderedComments.filter(
 			(rendered) => !body.contains(rendered.element),
 		);
 		body.replaceChildren();
-
-		toggle.hidden = empty;
-		toggle.textContent = empty ? "show" : "hide";
-		toggle.setAttribute("aria-expanded", empty ? "false" : "true");
-		section.classList.toggle("is-collapsed", empty);
-		body.style.maxHeight = empty ? "0px" : "";
 
 		if (discussion) {
 			const thread = notesThread(discussion);
@@ -14218,11 +14268,6 @@ ${SUBMIT_FORM_CSS}
 	align-items:flex-start;
 }
 
-.comment-vote-slot-empty {
-	flex-basis:0;
-	width:0;
-}
-
 .comment-vote-slot {
 	flex:0 0 var(--vote-column);
 	width:var(--vote-column);
@@ -14231,6 +14276,15 @@ ${SUBMIT_FORM_CSS}
 	align-items:center;
 	align-self:stretch;
 	padding-top:1px;
+}
+
+.comment-vote-slot.comment-vote-slot-empty {
+	flex-basis:0;
+	width:0;
+}
+
+.comment-vote-slot.comment-vote-slot-empty::after {
+	display:none;
 }
 
 .comment-vote-slot::after {
@@ -16400,7 +16454,7 @@ ${settingsPanelHTML()}
       <div class="comment-main">
       <div class="meta">
 
-      ${authorLinkHTML(comment.source, comment.author, comment.authorName)}
+      ${isLocalSource ? "" : authorLinkHTML(comment.source, comment.author, comment.authorName)}
 
 		${comment.isOP ? `<span class="op-pill">OP</span>` : ""}
 
@@ -16839,24 +16893,7 @@ ${settingsPanelHTML()}
 		if (settings.notepad && notes.length) {
 			const held = notesSection({ empty: false });
 
-			const storyCell = disambiguating
-				? null
-				: ui.body.querySelector(".submission-detail .story-body-cell");
-
-			if (storyCell) {
-				held.section.classList.add("notepad-section-inline");
-				storyCell.insertBefore(
-					held.section,
-					storyCell.querySelector(".comment-composer"),
-				);
-			} else {
-				ui.body.insertBefore(
-					held.section,
-					ui.body.querySelector(".compose-box") ||
-						ui.body.querySelector(".page-sort") ||
-						comments,
-				);
-			}
+			placeNotesSection(ui, held.section);
 
 			if (notesDiscussion) {
 				const thread = notesThread(notesDiscussion);
@@ -17088,7 +17125,6 @@ ${settingsPanelHTML()}
 		const body = document.createElement("div");
 		const foot = document.createElement("div");
 		const toggle = document.createElement("button");
-		const add = document.createElement("button");
 
 		section.className = "notepad-section";
 		section.dataset.notesSection = "1";
@@ -17098,7 +17134,7 @@ ${settingsPanelHTML()}
 
 		toggle.type = "button";
 		toggle.className = "notepad-toggle";
-		toggle.textContent = empty ? "show" : "hide";
+		toggle.textContent = empty ? "[+]" : "[\u2013]";
 		toggle.hidden = empty;
 		toggle.setAttribute("aria-expanded", empty ? "false" : "true");
 
@@ -17115,7 +17151,7 @@ ${settingsPanelHTML()}
 				: body.scrollHeight
 					? `${body.scrollHeight}px`
 					: "";
-			toggle.textContent = collapsed ? "show" : "hide";
+			toggle.textContent = collapsed ? "[+]" : "[\u2013]";
 			toggle.setAttribute("aria-expanded", collapsed ? "false" : "true");
 			body.style.overflow = "hidden";
 


### PR DESCRIPTION
# v1.6.11

## Features
- Comment Composer: now there is a single, simple comment box that lets you submit notes and comments from the same place, and intelligently let's you select where your commentary should go, even in multi-source discussions
   - Also adds a new button to the sidebar header if you decide you want to note/comment midway through a long discussion
- Blended discussions now show their sources in a nicely organized dropdown 
- Prioritize unread let's you, unsurprisingly, prioritize unread message when you return to a discussion 
- Notepad UI cleaned up
- Skeleton loading UI for front pages

## Fixes
- Mobile version shouldn't block source-specific  actions due to 'Popup window blocked'
- Hide the notification setting on mobile
- Fixes for links not being clickable under highlighting
- Highlights now update their position aggressively, preventing them getting stuck in an old position
- Fixes for voting arrows getting stuck
- Fixed sorting not being available for every discussion
- Fixes for sorting marking all posts as read
- Fixes for indent guides sometimes not showing up
- Made 'front pages', 'queue', and 'collection' more obviously clickable
- Made the non-voted arrow more obviously non-voted
- Fixes for left-alignment & columns being preserved but content that was never coming